### PR TITLE
fix: remove dead code and improve error handling

### DIFF
--- a/Wallhavend/WallhavenAPI.swift
+++ b/Wallhavend/WallhavenAPI.swift
@@ -42,14 +42,6 @@ enum WallhavenCategory: String, CaseIterable {
 	case general
 	case anime
 	case people
-
-	var code: String {
-		switch self {
-			case .general: return "1"
-			case .anime: return "0"
-			case .people: return "0"
-		}
-	}
 }
 
 class WallhavenService: ObservableObject {
@@ -216,7 +208,7 @@ class WallhavenService: ObservableObject {
 		let apiResponse = try JSONDecoder().decode(WallhavenResponse.self, from: data)
 
 		if apiResponse.data.isEmpty {
-			throw WallpaperError.zeroByteResource
+			throw WallpaperError.noResults
 		}
 
 		cachedWallpapers = apiResponse.data

--- a/Wallhavend/WallpaperError.swift
+++ b/Wallhavend/WallpaperError.swift
@@ -3,10 +3,11 @@ import Foundation
 enum WallpaperError: LocalizedError {
 	case invalidURL
 	case invalidResponse
+	case httpError(Int)
 	case noContentType
 	case unsupportedImageType(String)
 	case invalidImage
-	case zeroByteResource
+	case noResults
 
 	var errorDescription: String? {
 		switch self {
@@ -14,14 +15,16 @@ enum WallpaperError: LocalizedError {
 				return "Invalid wallpaper URL"
 			case .invalidResponse:
 				return "Invalid response type"
+			case .httpError(let statusCode):
+				return "Download failed with HTTP \(statusCode)"
 			case .noContentType:
 				return "No content type in response"
 			case .unsupportedImageType(let type):
 				return "Unsupported image type: \(type)"
 			case .invalidImage:
 				return "Failed to load downloaded image"
-			case .zeroByteResource:
-				return "The response is literally empty."
+			case .noResults:
+				return "No wallpapers found matching your search criteria"
 		}
 	}
 }

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -38,7 +38,6 @@ class WallpaperManager: ObservableObject {
 	var currentWallpaperFileURL: URL?
 	var previousWallpaperFileURL: URL?
 	private var deletionWorkItem: DispatchWorkItem?
-	private var errorDismissTask: Task<Void, Never>?
 
 	@Published
 	var isRunning = false
@@ -209,7 +208,6 @@ class WallpaperManager: ObservableObject {
 
 		do {
 			error = nil
-			errorDismissTask?.cancel()
 
 			print("Restoring previous wallpaper: \(previousURL.lastPathComponent)")
 			try setWallpaperForAllScreens(url: previousURL, image: image)
@@ -250,6 +248,10 @@ class WallpaperManager: ObservableObject {
 
 		print("Download complete. Status: \(httpResponse.statusCode), Size: \(data.count) bytes")
 
+		guard httpResponse.statusCode == 200 else {
+			throw WallpaperError.httpError(httpResponse.statusCode)
+		}
+
 		guard let mimeType = httpResponse.mimeType else {
 			throw WallpaperError.noContentType
 		}
@@ -281,7 +283,7 @@ class WallpaperManager: ObservableObject {
 			.appendingPathComponent("Desktop Pictures", isDirectory: true)
 			.appendingPathComponent("Wallhavend", isDirectory: true)
 
-		try? FileManager.default.createDirectory(at: desktopPicturesURL, withIntermediateDirectories: true)
+		try FileManager.default.createDirectory(at: desktopPicturesURL, withIntermediateDirectories: true)
 		return desktopPicturesURL
 	}
 


### PR DESCRIPTION
- remove unused `WallhavenCategory.code` (values were also wrong)
- remove unimplemented `errorDismissTask`
- validate HTTP status code in `downloadWallpaper`
- propagate `createDirectory` errors instead of silencing them
- rename `zeroByteResource` to `noResults` with a clearer message