### PR TITLE
fix: gallery delete flicker, API decode failure, NSImage Sendable warning

### DIFF
--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -418,7 +418,6 @@ private struct WallpaperThumbnailView: View {
 				.stroke(Color.accentColor, lineWidth: isCurrent ? 2 : 0)
 			)
 			.onTapGesture(perform: onApply)
-			.onHover { isHovered = $0 }
 
 			if isHovered {
 				Button(action: onDelete) {
@@ -434,12 +433,10 @@ private struct WallpaperThumbnailView: View {
 		}
 		.frame(maxWidth: .infinity, minHeight: 64, maxHeight: 64)
 		.contentShape(Rectangle())
+		.onHover { isHovered = $0 }
 		.task(id: url) {
-			let imageLoadingTask = Task.detached(priority: .userInitiated) {
-				NSImage(contentsOf: url)
-			}
-
-			nsImage = await imageLoadingTask.value
+			let loadTask = Task.detached(priority: .userInitiated) { try? Data(contentsOf: url) }
+			nsImage = await loadTask.value.flatMap { NSImage(data: $0) }
 		}
 	}
 }

--- a/Wallhavend/WallhavenAPI.swift
+++ b/Wallhavend/WallhavenAPI.swift
@@ -1,12 +1,12 @@
 import Foundation
 import SwiftUI
 
-struct WallhavenResponse: Codable {
+struct WallhavenResponse: Decodable {
 	let data: [Wallpaper]
 	let meta: Meta
 }
 
-struct Wallpaper: Codable {
+struct Wallpaper: Decodable {
 	let id: String
 	let url: String
 	let path: String
@@ -23,18 +23,25 @@ struct Wallpaper: Codable {
 	}
 }
 
-struct Meta: Codable {
+struct Meta: Decodable {
 	let currentPage: Int
 	let lastPage: Int
-	let perPage: Int
 	let total: Int
-	let query: String?
 
 	enum CodingKeys: String, CodingKey {
 		case currentPage = "current_page"
 		case lastPage = "last_page"
 		case perPage = "per_page"
-		case total, query
+		case total
+	}
+
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		currentPage = try container.decode(Int.self, forKey: .currentPage)
+		lastPage = try container.decode(Int.self, forKey: .lastPage)
+		total = try container.decode(Int.self, forKey: .total)
+		// perPage can be Int or String depending on the API version; skip it
+		// query can be String, null, or {"id":…,"tag":…} for tag searches; skip it
 	}
 }
 
@@ -204,7 +211,12 @@ class WallhavenService: ObservableObject {
 			request.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
 		}
 
-		let (data, _) = try await URLSession.shared.data(for: request)
+		let (data, response) = try await URLSession.shared.data(for: request)
+
+		if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+			throw WallpaperError.httpError(httpResponse.statusCode)
+		}
+
 		let apiResponse = try JSONDecoder().decode(WallhavenResponse.self, from: data)
 
 		if apiResponse.data.isEmpty {


### PR DESCRIPTION
## Summary

- Move `onHover` to the `ZStack` container in `WallpaperThumbnailView` so the delete button stays visible while the cursor is over it, preventing the flicker/disappear loop
- Check HTTP status before decoding Wallhaven API responses so a bad API key surfaces as a proper error instead of a confusing decode crash; make `Meta` use a custom `Decodable` init that skips `query` (can be a string or object) and `perPage` (can be a string or int)
- Load thumbnail `Data` on the background task and construct `NSImage` on the main actor to avoid the `NSImage: Sendable` availability warning (macOS 14+ only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)