### PR TITLE
feature: cycle through pool oldest-to-newest when offline

### DIFF
--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -150,7 +150,12 @@ class WallpaperManager: ObservableObject {
 		guard isRunning else { return }
 
 		guard isOnline else {
-			print("Offline. Skipping auto-update.")
+			if let oldest = poolPaths.last {
+				await applyFromPool(url: oldest)
+			} else {
+				print("Offline and pool is empty. Skipping auto-update.")
+			}
+
 			return
 		}
 


### PR DESCRIPTION
## Summary

- When offline and auto-update is running, apply the oldest wallpaper in the pool each tick instead of skipping
- Since `applyFromPool` moves the applied entry to the front of `poolPaths`, picking `poolPaths.last` each time naturally cycles oldest → newest with no index tracking needed
- If the pool is empty, silently skips (same as before)

Closes #39

🤖 Generated with [Claude Code](https://claude.ai/claude-code)