### PR TITLE
feature: aspect ratio preset chips and multi-ratio support

### DIFF
--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -174,6 +174,8 @@ private struct ContentTab: View {
 		)
 	}
 
+	private let presetRatios = ["16x9", "16x10", "21x9", "4x3"]
+
 	private var ratiosBinding: Binding<String> {
 		Binding(
 			get: { wallhavenService.ratios },
@@ -217,7 +219,21 @@ private struct ContentTab: View {
 
 				Divider()
 
-				TextField("Aspect Ratio (e.g. 16x9)", text: ratiosBinding)
+				HStack(spacing: 6) {
+					ForEach(presetRatios, id: \.self) { ratio in
+						Toggle(isOn: Binding(
+							get: { wallhavenService.isRatioSelected(ratio) },
+							set: { _ in wallhavenService.toggleRatio(ratio) }
+						)) {
+							Text(ratio)
+						}
+						.toggleStyle(.button)
+						.controlSize(.small)
+						.font(.system(.body, design: .monospaced))
+					}
+				}
+
+				TextField("e.g. 16x9,21x9", text: ratiosBinding)
 					.textFieldStyle(.roundedBorder)
 					.font(.system(.body, design: .monospaced))
 

--- a/Wallhavend/WallhavenAPI.swift
+++ b/Wallhavend/WallhavenAPI.swift
@@ -65,7 +65,7 @@ class WallhavenService: ObservableObject {
 	var apiKey: String = ""
 
 	@AppStorage("ratios")
-	var ratios: String = "16x9"
+	var ratios: String = ""
 
 	@AppStorage("includeSFW")
 	var includeSFW: Bool = true
@@ -235,16 +235,41 @@ class WallhavenService: ObservableObject {
 		.joined()
 	}
 
+	func isRatioSelected(_ ratio: String) -> Bool {
+		ratios
+			.split(separator: ",")
+			.map { $0.trimmingCharacters(in: .whitespaces) }
+			.contains(ratio)
+	}
+
+	func toggleRatio(_ ratio: String) {
+		var parts = ratios
+			.split(separator: ",")
+			.map { $0.trimmingCharacters(in: .whitespaces) }
+			.filter { !$0.isEmpty }
+
+		if let index = parts.firstIndex(of: ratio) {
+			parts.remove(at: index)
+		} else {
+			parts.append(ratio)
+		}
+
+		ratios = parts.joined(separator: ",")
+	}
+
 	private func buildQueryItems(_ categoriesString: String) -> [URLQueryItem] {
 		var items = [
 			URLQueryItem(name: "q", value: searchQuery),
 			URLQueryItem(name: "categories", value: categoriesString),
 			URLQueryItem(name: "purity", value: purityString),
-			URLQueryItem(name: "ratios", value: ratios),
 			URLQueryItem(name: "sorting", value: "random"),
 			URLQueryItem(name: "seed", value: UUID().uuidString),
 			URLQueryItem(name: "atleast", value: ratioResolution)
 		]
+
+		if !ratios.isEmpty {
+			items.append(URLQueryItem(name: "ratios", value: ratios))
+		}
 
 		if !apiKey.isEmpty {
 			items.append(URLQueryItem(name: "apikey", value: apiKey))

--- a/WallhavendTests/WallhavendTests.swift
+++ b/WallhavendTests/WallhavendTests.swift
@@ -116,6 +116,45 @@ final class WallhavendTests: XCTestCase {
 		XCTAssertEqual(peopleWallpaper.category, "people")
 	}
 
+	func testToggleRatioAdds() {
+		service.ratios = ""
+		service.toggleRatio("16x9")
+		XCTAssertEqual(service.ratios, "16x9")
+	}
+
+	func testToggleRatioRemoves() {
+		service.ratios = "16x9"
+		service.toggleRatio("16x9")
+		XCTAssertEqual(service.ratios, "")
+	}
+
+	func testToggleRatioAddsSecond() {
+		service.ratios = "16x9"
+		service.toggleRatio("21x9")
+		XCTAssertTrue(service.isRatioSelected("16x9"))
+		XCTAssertTrue(service.isRatioSelected("21x9"))
+	}
+
+	func testToggleRatioRemovesOneOfMultiple() {
+		service.ratios = "16x9,21x9"
+		service.toggleRatio("16x9")
+		XCTAssertFalse(service.isRatioSelected("16x9"))
+		XCTAssertTrue(service.isRatioSelected("21x9"))
+		XCTAssertEqual(service.ratios, "21x9")
+	}
+
+	func testIsRatioSelectedHandlesWhitespace() {
+		service.ratios = "16x9, 21x9"
+		XCTAssertTrue(service.isRatioSelected("21x9"))
+	}
+
+	func testToggleRatioTrimsWhitespace() {
+		service.ratios = "16x9, 21x9"
+		service.toggleRatio("21x9")
+		XCTAssertFalse(service.isRatioSelected("21x9"))
+		XCTAssertTrue(service.isRatioSelected("16x9"))
+	}
+
 	func testSearchQueryEncoding() async throws {
 		service.searchQuery = "mountain landscape"
 


### PR DESCRIPTION
## Summary

- Add toggle chips for common desktop ratios (16x9, 16x10, 21x9, 4x3) in the Content Filters section
- Chips and text field share the same comma-separated `ratios` string — both stay in sync, manual input is never blocked
- `ratios` query parameter is omitted when blank (no ratio filter applied)
- Ratio toggle logic moved to `WallhavenService` as `isRatioSelected(_:)` / `toggleRatio(_:)` with unit tests

Closes #36

🤖 Generated with [Claude Code](https://claude.ai/claude-code)