### PR TITLE
Fix memory and concurrency bugs & apply guard style

### DIFF
--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -383,12 +383,17 @@ private struct WallpaperThumbnailView: View {
 					kCGImageSourceThumbnailMaxPixelSize: 300,
 					kCGImageSourceCreateThumbnailWithTransform: true
 				]
-				guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-					  let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+
+				guard
+					let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+					let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+				else {
 					return nil as NSImage?
 				}
+
 				return NSImage(cgImage: cgImage, size: .zero)
 			}
+
 			nsImage = await loadTask.value
 		}
 	}

--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import ImageIO
 
 struct ContentView: View {
 	@EnvironmentObject
@@ -376,8 +377,19 @@ private struct WallpaperThumbnailView: View {
 			}
 		}
 		.task(id: url) {
-			let loadTask = Task.detached(priority: .userInitiated) { try? Data(contentsOf: url) }
-			nsImage = await loadTask.value.flatMap { NSImage(data: $0) }
+			let loadTask = Task.detached(priority: .userInitiated) {
+				let options: [CFString: Any] = [
+					kCGImageSourceCreateThumbnailFromImageAlways: true,
+					kCGImageSourceThumbnailMaxPixelSize: 300,
+					kCGImageSourceCreateThumbnailWithTransform: true
+				]
+				guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+					  let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+					return nil as NSImage?
+				}
+				return NSImage(cgImage: cgImage, size: .zero)
+			}
+			nsImage = await loadTask.value
 		}
 	}
 }

--- a/Wallhavend/StatusBarController.swift
+++ b/Wallhavend/StatusBarController.swift
@@ -43,9 +43,11 @@ class StatusBarController {
 
 	private func updateStatusBarIcon(isOnline: Bool, isRunning: Bool) {
 		guard let button = statusItem.button else { return }
+
 		let iconSize = NSSize(width: 18, height: 18)
 
 		guard let baseImage = NSImage(named: NSImage.Name("MenuBarIcon")) else { return }
+
 		baseImage.size = iconSize
 
 		if !isOnline {
@@ -92,6 +94,7 @@ class StatusBarController {
 	@objc
 	private func handleClick(_ sender: AnyObject?) {
 		guard let event = NSApp.currentEvent else { return }
+
 		if event.type == .rightMouseUp {
 			closePopover()
 			toggleAutoUpdate()

--- a/Wallhavend/WallhavenAPI.swift
+++ b/Wallhavend/WallhavenAPI.swift
@@ -49,6 +49,7 @@ enum WallhavenCategory: String, CaseIterable {
 	case people
 }
 
+@MainActor
 class WallhavenService: ObservableObject {
 	static let shared = WallhavenService()
 	let baseURL = "https://wallhaven.cc/api/v1"

--- a/Wallhavend/WallpaperManager+Pool.swift
+++ b/Wallhavend/WallpaperManager+Pool.swift
@@ -17,7 +17,9 @@ extension WallpaperManager {
 				at: bucketDir,
 				includingPropertiesForKeys: [.contentModificationDateKey],
 				options: .skipsHiddenFiles
-			) else { continue }
+			) else {
+				continue
+			}
 
 			let sorted = files.sorted { left, right in
 				let leftDate = (try? left.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
@@ -54,11 +56,13 @@ extension WallpaperManager {
 	@discardableResult
 	nonisolated static func migrateFlatFilesToBuckets(in storageURL: URL) -> Int {
 		let fileManager = FileManager.default
-		guard let entries = try? fileManager.contentsOfDirectory(
-			at: storageURL,
-			includingPropertiesForKeys: [.isDirectoryKey],
-			options: .skipsHiddenFiles
-		) else {
+		guard
+			let entries = try? fileManager.contentsOfDirectory(
+				at: storageURL,
+				includingPropertiesForKeys: [.isDirectoryKey],
+				options: .skipsHiddenFiles
+			)
+		else {
 			return 0
 		}
 
@@ -180,7 +184,9 @@ extension WallpaperManager {
 
 			for bucket in AspectBucket.allCases {
 				let dir = storageURL.appendingPathComponent(bucket.rawValue, isDirectory: true)
-				guard let files = try? fileManager.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil) else {
+				guard
+					let files = try? fileManager.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
+				else {
 					continue
 				}
 

--- a/Wallhavend/WallpaperManager+Wallpaper.swift
+++ b/Wallhavend/WallpaperManager+Wallpaper.swift
@@ -42,12 +42,14 @@ extension WallpaperManager {
 			)
 
 			let (data, fileExtension) = try await downloadWallpaper(from: wallpaper.path)
-			let wallpaperPath = try saveWallpaper(
-				data: data,
-				id: wallpaper.id,
-				fileExtension: fileExtension,
-				bucket: bucket
-			)
+			let wallpaperPath = try await Task.detached(priority: .userInitiated) {
+				try self.saveWallpaper(
+					data: data,
+					id: wallpaper.id,
+					fileExtension: fileExtension,
+					bucket: bucket
+				)
+			}.value
 
 			try applyWallpaper(url: wallpaperPath, to: screens)
 
@@ -119,7 +121,7 @@ extension WallpaperManager {
 		throw WallpaperError.unsupportedImageType(mimeType)
 	}
 
-	func getWallpaperStorageDirectory() throws -> URL {
+	nonisolated func getWallpaperStorageDirectory() throws -> URL {
 		let libraryURL = try FileManager.default.url(
 			for: .libraryDirectory,
 			in: .userDomainMask,
@@ -135,7 +137,7 @@ extension WallpaperManager {
 		return desktopPicturesURL
 	}
 
-	private func saveWallpaper(data: Data, id: String, fileExtension: String, bucket: AspectBucket) throws -> URL {
+	nonisolated private func saveWallpaper(data: Data, id: String, fileExtension: String, bucket: AspectBucket) throws -> URL {
 		let storageURL = try getWallpaperStorageDirectory()
 		let bucketDir = storageURL.appendingPathComponent(bucket.rawValue, isDirectory: true)
 		try FileManager.default.createDirectory(at: bucketDir, withIntermediateDirectories: true)

--- a/Wallhavend/WallpaperManager+Wallpaper.swift
+++ b/Wallhavend/WallpaperManager+Wallpaper.swift
@@ -65,7 +65,10 @@ extension WallpaperManager {
 
 	@MainActor
 	private func rotatePoolForBucket(bucket: AspectBucket, screens: [NSScreen]) async {
-		guard let list = poolsByBucket[bucket.rawValue], let oldest = list.last else {
+		guard
+			let list = poolsByBucket[bucket.rawValue],
+			let oldest = list.last
+		else {
 			print("Offline and pool empty for \(bucket.rawValue). Skipping.")
 			return
 		}

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -92,6 +92,7 @@ class WallpaperManager: ObservableObject {
 			.dropFirst()
 			.sink { [weak self] isOnline in
 				guard let self else { return }
+
 				Task { @MainActor [weak self] in
 					guard let self else { return }
 
@@ -147,6 +148,7 @@ class WallpaperManager: ObservableObject {
 			queue: .main
 		) { [weak self] _ in
 			guard let self else { return }
+
 			Task { @MainActor in self.isSessionActive = false }
 		}
 
@@ -156,6 +158,7 @@ class WallpaperManager: ObservableObject {
 			queue: .main
 		) { [weak self] _ in
 			guard let self else { return }
+
 			Task { @MainActor in self.isSessionActive = true }
 		}
 	}

--- a/WallhavendTests/PoolMigrationTests.swift
+++ b/WallhavendTests/PoolMigrationTests.swift
@@ -5,18 +5,20 @@ import ImageIO
 
 final class PoolMigrationTests: XCTestCase {
 	private func writePNG(width: Int, height: Int, to url: URL) throws {
-		guard let rep = NSBitmapImageRep(
-			bitmapDataPlanes: nil,
-			pixelsWide: width,
-			pixelsHigh: height,
-			bitsPerSample: 8,
-			samplesPerPixel: 4,
-			hasAlpha: true,
-			isPlanar: false,
-			colorSpaceName: .deviceRGB,
-			bytesPerRow: 0,
-			bitsPerPixel: 0
-		) else {
+		guard
+			let rep = NSBitmapImageRep(
+				bitmapDataPlanes: nil,
+				pixelsWide: width,
+				pixelsHigh: height,
+				bitsPerSample: 8,
+				samplesPerPixel: 4,
+				hasAlpha: true,
+				isPlanar: false,
+				colorSpaceName: .deviceRGB,
+				bytesPerRow: 0,
+				bitsPerPixel: 0
+			)
+		else {
 			throw XCTSkip("Could not create bitmap rep")
 		}
 

--- a/WallhavendTests/WallhavendTests.swift
+++ b/WallhavendTests/WallhavendTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Wallhavend
 
+@MainActor
 final class WallhavendTests: XCTestCase {
 	var service: WallhavenService!
 


### PR DESCRIPTION
This PR introduces several crucial fixes and formatting improvements:

- **Fixes #48:** Resolves the `WallhavenService` data race by isolating it to `@MainActor`.
- **Fixes #49:** Prevents main thread blocking by offloading `saveWallpaper` file I/O to a detached task.
- **Fixes #50:** Reduces the gallery's memory footprint by using `ImageIO` for efficient thumbnail generation.
- Applies consistent formatting rules for `guard` clauses across the codebase.