### PR TITLE
feature: add button to open wallpaper pool in Finder

### DIFF
--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -252,9 +252,19 @@ private struct AdvancedTab: View {
 				}
 				.pickerStyle(.segmented)
 
-				Text("Wallpapers kept on device and shown in Gallery tab")
+				HStack {
+					Text("Wallpapers kept on device and shown in Gallery tab")
+						.font(.caption)
+						.foregroundColor(.secondary)
+
+					Spacer()
+
+					Button("Show in Finder") {
+						wallpaperManager.openStorageDirectoryInFinder()
+					}
 					.font(.caption)
-					.foregroundColor(.secondary)
+					.buttonStyle(.link)
+				}
 			}
 			.padding(.vertical, 4)
 		} label: {

--- a/Wallhavend/WallpaperManager+Pool.swift
+++ b/Wallhavend/WallpaperManager+Pool.swift
@@ -161,6 +161,12 @@ extension WallpaperManager {
 		NSWorkspace.shared.selectFile(url.path, inFileViewerRootedAtPath: url.deletingLastPathComponent().path)
 	}
 
+	func openStorageDirectoryInFinder() {
+		guard let url = try? getWallpaperStorageDirectory() else { return }
+
+		NSWorkspace.shared.open(url)
+	}
+
 	func copyWallhavenURL(for url: URL) {
 		let id = url.deletingPathExtension().lastPathComponent
 		let pasteboard = NSPasteboard.general


### PR DESCRIPTION
Adds a button in the Advanced settings tab to quickly open the local wallpaper storage directory in Finder.