### PR TITLE
Auto-replace when blocking the current wallpaper

### DIFF
--- a/Wallhavend.xcodeproj/project.pbxproj
+++ b/Wallhavend.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AA0000012F600000000ASPC2 /* AspectBucketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000ASPC2 /* AspectBucketTests.swift */; };
 		AA0000012F600000000BLOK1 /* BlocklistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000BLOK1 /* BlocklistTests.swift */; };
 		AA0000012F600000000MIG1 /* PoolMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000MIG1 /* PoolMigrationTests.swift */; };
+		AA0000012F600000000REPL1 /* AutoReplaceOnBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000REPL1 /* AutoReplaceOnBlockTests.swift */; };
 		AA0000012F600000000POOL1 /* WallpaperManager+Pool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000POOL1 /* WallpaperManager+Pool.swift */; };
 		AA0000012F600000000WALL1 /* WallpaperManager+Wallpaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */; };
 		D01707E62DCC4F3E00158EDD /* WallhavenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01707E32DCC4F3E00158EDD /* WallhavenAPI.swift */; };
@@ -49,6 +50,7 @@
 		AA0000002F600000000ASPC2 /* AspectBucketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AspectBucketTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000BLOK1 /* BlocklistTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlocklistTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000MIG1 /* PoolMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoolMigrationTests.swift; sourceTree = "<group>"; };
+		AA0000002F600000000REPL1 /* AutoReplaceOnBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoReplaceOnBlockTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000POOL1 /* WallpaperManager+Pool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Pool.swift"; sourceTree = "<group>"; };
 		AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Wallpaper.swift"; sourceTree = "<group>"; };
 		D01707E32DCC4F3E00158EDD /* WallhavenAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallhavenAPI.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				AA0000002F600000000ASPC2 /* AspectBucketTests.swift */,
 				AA0000002F600000000BLOK1 /* BlocklistTests.swift */,
 				AA0000002F600000000MIG1 /* PoolMigrationTests.swift */,
+				AA0000002F600000000REPL1 /* AutoReplaceOnBlockTests.swift */,
 				D0ED74A92DCB72F90008C397 /* WallhavendTests.swift */,
 			);
 			path = WallhavendTests;
@@ -284,6 +287,7 @@
 				AA0000012F600000000ASPC2 /* AspectBucketTests.swift in Sources */,
 				AA0000012F600000000BLOK1 /* BlocklistTests.swift in Sources */,
 				AA0000012F600000000MIG1 /* PoolMigrationTests.swift in Sources */,
+				AA0000012F600000000REPL1 /* AutoReplaceOnBlockTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Wallhavend.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Wallhavend.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
-        "version" : "2.9.2"
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     }
   ],

--- a/Wallhavend/GalleryTab.swift
+++ b/Wallhavend/GalleryTab.swift
@@ -102,7 +102,7 @@ private struct WallpaperThumbnailView: View {
 			Divider()
 
 			Button("Block this wallpaper", role: .destructive) {
-				wallpaperManager.blockWallpaper(url: url)
+				Task { await wallpaperManager.blockWallpaper(url: url) }
 			}
 
 			Button("Delete from pool", role: .destructive) {

--- a/Wallhavend/WallpaperManager+Pool.swift
+++ b/Wallhavend/WallpaperManager+Pool.swift
@@ -187,11 +187,68 @@ extension WallpaperManager {
 		pasteboard.setString("https://wallhaven.cc/w/\(id)", forType: .string)
 	}
 
+	/// What to do after a wallpaper is blocked, given whether it was the current one and what's left in the bucket's pool.
+	enum BlockReplacementAction: Equatable {
+		case doNothing
+		case applyFromPool(URL)
+		case fetch
+	}
+
+	/// Decide how to replace a just-blocked wallpaper for one bucket: nothing when it wasn't current, the oldest
+	/// remaining non-blocked pool entry when one exists, otherwise a fetch. `blockedIds` already includes the just-blocked id.
+	nonisolated static func replacementAction(wasCurrent: Bool, pool: [URL], blockedIds: Set<String>) -> BlockReplacementAction {
+		guard wasCurrent else {
+			return .doNothing
+		}
+
+		let oldestUsable = pool.last { !blockedIds.contains($0.deletingPathExtension().lastPathComponent) }
+
+		guard let oldestUsable else {
+			return .fetch
+		}
+
+		return .applyFromPool(oldestUsable)
+	}
+
 	/// Block a wallpaper so it's never applied again, and evict any on-disk copy immediately — the user wants it gone now, not just on the next fetch.
-	func blockWallpaper(url: URL) {
+	/// If it was the wallpaper currently on screen, replace it right away (pool-first, fetch as fallback) so the user stops looking at what they just blocked.
+	func blockWallpaper(url: URL) async {
 		let id = wallpaperId(for: url)
+
+		// Capture the buckets currently showing this wallpaper before eviction repoints currentByBucket and erases the signal.
+		let affectedBuckets = AspectBucket.allCases.filter { bucket in
+			guard let current = currentByBucket[bucket.rawValue] else {
+				return false
+			}
+
+			return wallpaperId(for: current) == id
+		}
+
 		WallhavenService.shared.block(id)
 		evictFromPool(id: id)
+
+		for bucket in affectedBuckets {
+			await replaceBlockedCurrent(in: bucket)
+		}
+	}
+
+	/// Replace a bucket's just-blocked current wallpaper: prefer a remaining pool item, otherwise fall back to a normal update (fetch online, no-op offline with an empty pool).
+	private func replaceBlockedCurrent(in bucket: AspectBucket) async {
+		let action = Self.replacementAction(wasCurrent: true, pool: poolsByBucket[bucket.rawValue] ?? [], blockedIds: WallhavenService.shared.blockedIds)
+
+		switch action {
+			case .doNothing:
+				return
+			case .applyFromPool(let replacement):
+				await applyFromPool(url: replacement, bucket: bucket.rawValue)
+			case .fetch:
+				let screens = NSScreen.screens.filter { AspectBucket.forScreen($0).rawValue == bucket.rawValue }
+				guard !screens.isEmpty else {
+					return
+				}
+
+				await updateBucket(bucket, screens: screens)
+		}
 	}
 
 	/// Remove every copy of `id` from the pool and disk, across all buckets — the same image can be saved under more than one bucket.

--- a/Wallhavend/WallpaperManager+Wallpaper.swift
+++ b/Wallhavend/WallpaperManager+Wallpaper.swift
@@ -32,6 +32,15 @@ extension WallpaperManager {
 		}
 	}
 
+	/// Run the normal update for a single bucket, respecting connectivity: fetch fresh when online, otherwise rotate the pool (a no-op when the pool is empty).
+	func updateBucket(_ bucket: AspectBucket, screens: [NSScreen]) async {
+		if isOnline {
+			await updateWallpaperForBucket(bucket: bucket, screens: screens)
+		} else {
+			await rotatePoolForBucket(bucket: bucket, screens: screens)
+		}
+	}
+
 	@MainActor
 	private func updateWallpaperForBucket(bucket: AspectBucket, screens: [NSScreen]) async {
 		do {

--- a/WallhavendTests/AutoReplaceOnBlockTests.swift
+++ b/WallhavendTests/AutoReplaceOnBlockTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import Wallhavend
+
+@MainActor
+final class AutoReplaceOnBlockTests: XCTestCase {
+	/// A pool URL whose filename stem is the wallhaven id (see `WallpaperManager.wallpaperId(for:)`).
+	private func url(_ id: String) -> URL {
+		URL(fileURLWithPath: "/tmp/16x9/\(id).jpg")
+	}
+
+	// Pools are stored newest-first, so "oldest remaining" is the last non-blocked entry.
+
+	func testCurrentWithNonEmptyPoolAppliesOldestRemaining() {
+		let action = WallpaperManager.replacementAction(
+			wasCurrent: true,
+			pool: [url("newest"), url("middle"), url("oldest")],
+			blockedIds: ["blockedId"]
+		)
+
+		XCTAssertEqual(action, .applyFromPool(url("oldest")))
+	}
+
+	func testCurrentWithEmptyPoolFallsBackToFetch() {
+		let action = WallpaperManager.replacementAction(
+			wasCurrent: true,
+			pool: [],
+			blockedIds: ["blockedId"]
+		)
+
+		XCTAssertEqual(action, .fetch)
+	}
+
+	func testCurrentWithOnlyBlockedEntriesFallsBackToFetch() {
+		// Defensive: a blocked straggler must never be applied — fall through to a fetch.
+		let action = WallpaperManager.replacementAction(
+			wasCurrent: true,
+			pool: [url("blockedId")],
+			blockedIds: ["blockedId"]
+		)
+
+		XCTAssertEqual(action, .fetch)
+	}
+
+	func testReplacementSkipsBlockedStragglerAndPicksNextOldest() {
+		// The oldest entry (last) is blocked, so the next-oldest usable one wins.
+		let action = WallpaperManager.replacementAction(
+			wasCurrent: true,
+			pool: [url("usable"), url("blockedId")],
+			blockedIds: ["blockedId"]
+		)
+
+		XCTAssertEqual(action, .applyFromPool(url("usable")))
+	}
+
+	func testNonCurrentBlockReplacesNothing() {
+		let action = WallpaperManager.replacementAction(
+			wasCurrent: false,
+			pool: [url("anything")],
+			blockedIds: ["blockedId"]
+		)
+
+		XCTAssertEqual(action, .doNothing)
+	}
+}


### PR DESCRIPTION
## Summary

Blocking the wallpaper currently on screen evicted it from the pool but never repainted the desktop, so macOS kept showing the just-blocked image until the next scheduled update. Now, when the blocked wallpaper is the one applied on a bucket's screens, it is replaced immediately.

**Decision tree (per aspect bucket; mirrors the Android side in Attacktive/Wallhavend-android#69):**

1. **Pool-first** — apply the *oldest* remaining non-blocked pool entry, reusing the rotation semantics already in `rotatePoolForBucket`.
2. **Fetch fallback** — only when that bucket's pool is empty or all-blocked, run a normal connectivity-aware update via a new `updateBucket` helper (fetch when online; no-op offline with an empty pool — same as today).

Blocking a wallpaper that is *not* current is unchanged (block + evict only). Matching is by Wallhaven id, so a wallpaper that is current across several buckets is replaced on each.

## Implementation

Mirrors how #59 extracted the pure `selectWallpaper`:

- A pure, testable `replacementAction(wasCurrent:pool:blockedIds:)` returning doNothing / applyFromPool / fetch.
- `blockWallpaper` is now `async` and captures which buckets show the id *before* eviction repoints `currentByBucket`, then acts per bucket. Its `GalleryTab` caller wraps it in a `Task`.
- `AutoReplaceOnBlockTests` cover the three required cases (current + non-empty pool → oldest remaining; current + empty/all-blocked → fetch; non-current → neither) plus a skip-blocked-straggler case.

The second commit bumps Sparkle 2.9.2 → 2.9.3 (latest within the existing `>=2.9.0 <3.0.0` constraint), kept separate from the feature.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)
