### PR TITLE
feature: pin wallpapers and add rotation mode picker

### DIFF
--- a/Wallhavend.xcodeproj/project.pbxproj
+++ b/Wallhavend.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		AA0000012F600000000BLOK1 /* BlocklistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000BLOK1 /* BlocklistTests.swift */; };
 		AA0000012F600000000MIG1 /* PoolMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000MIG1 /* PoolMigrationTests.swift */; };
 		AA0000012F600000000REPL1 /* AutoReplaceOnBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000REPL1 /* AutoReplaceOnBlockTests.swift */; };
+		AA0000012F600000000PINT1 /* PinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000PINT1 /* PinTests.swift */; };
 		AA0000012F600000000POOL1 /* WallpaperManager+Pool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000POOL1 /* WallpaperManager+Pool.swift */; };
 		AA0000012F600000000WALL1 /* WallpaperManager+Wallpaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */; };
 		D01707E62DCC4F3E00158EDD /* WallhavenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01707E32DCC4F3E00158EDD /* WallhavenAPI.swift */; };
@@ -51,6 +52,7 @@
 		AA0000002F600000000BLOK1 /* BlocklistTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlocklistTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000MIG1 /* PoolMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoolMigrationTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000REPL1 /* AutoReplaceOnBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoReplaceOnBlockTests.swift; sourceTree = "<group>"; };
+		AA0000002F600000000PINT1 /* PinTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000POOL1 /* WallpaperManager+Pool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Pool.swift"; sourceTree = "<group>"; };
 		AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Wallpaper.swift"; sourceTree = "<group>"; };
 		D01707E32DCC4F3E00158EDD /* WallhavenAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallhavenAPI.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 				AA0000002F600000000BLOK1 /* BlocklistTests.swift */,
 				AA0000002F600000000MIG1 /* PoolMigrationTests.swift */,
 				AA0000002F600000000REPL1 /* AutoReplaceOnBlockTests.swift */,
+				AA0000002F600000000PINT1 /* PinTests.swift */,
 				D0ED74A92DCB72F90008C397 /* WallhavendTests.swift */,
 			);
 			path = WallhavendTests;
@@ -288,6 +291,7 @@
 				AA0000012F600000000BLOK1 /* BlocklistTests.swift in Sources */,
 				AA0000012F600000000MIG1 /* PoolMigrationTests.swift in Sources */,
 				AA0000012F600000000REPL1 /* AutoReplaceOnBlockTests.swift in Sources */,
+				AA0000012F600000000PINT1 /* PinTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Wallhavend/AdvancedTab.swift
+++ b/Wallhavend/AdvancedTab.swift
@@ -18,7 +18,45 @@ struct AdvancedTab: View {
 		)
 	}
 
+	private var hasPins: Bool {
+		!wallhavenService.pinnedIds.isEmpty
+	}
+
+	private var rotationModeBinding: Binding<RotationMode> {
+		Binding(
+			get: { hasPins ? wallpaperManager.rotationMode : .fresh },
+			set: { wallpaperManager.rotationMode = ($0 == .pinnedOnly && !hasPins) ? .fresh : $0 }
+		)
+	}
+
+	private var rotationCaption: String {
+		if hasPins {
+			return "Fresh downloads new wallpapers (and rotates your pool when offline). Pinned only never downloads — it cycles just your pinned wallpapers. “Update Now” always fetches a fresh one."
+		} else {
+			return "Fresh downloads new wallpapers (and rotates your pool when offline). Pin a wallpaper to enable Pinned only."
+		}
+	}
+
 	var body: some View {
+		VStack(alignment: .leading, spacing: 6) {
+			Text("Rotation")
+				.font(.headline)
+
+			Picker("Rotation", selection: rotationModeBinding) {
+				ForEach(RotationMode.allCases) { mode in
+					Text(mode.label)
+						.tag(mode)
+						.disabled(mode == .pinnedOnly && !hasPins)
+				}
+			}
+			.labelsHidden()
+			.pickerStyle(.radioGroup)
+
+			Text(rotationCaption)
+				.font(.caption)
+				.foregroundColor(.secondary)
+		}
+
 		VStack(alignment: .leading, spacing: 6) {
 			Text("Wallpaper Pool")
 				.font(.headline)

--- a/Wallhavend/AdvancedTab.swift
+++ b/Wallhavend/AdvancedTab.swift
@@ -62,7 +62,7 @@ struct AdvancedTab: View {
 				.font(.headline)
 
 			Picker("Pool size", selection: poolSizeBinding) {
-				Text("Current only").tag(0)
+				Text("Current only").tag(1)
 				Text("5").tag(5)
 				Text("10").tag(10)
 				Text("25").tag(25)

--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -12,6 +12,11 @@ struct ContentView: View {
 
 	@State private var selectedTab = 0
 
+	/// Auto-update can run offline in Pinned-only mode (it never downloads), so don't gate it on connectivity there.
+	private var canStartAutoUpdate: Bool {
+		wallpaperManager.isOnline || wallpaperManager.isRunning || wallpaperManager.effectiveRotationMode == .pinnedOnly
+	}
+
 	var body: some View {
 		VStack(spacing: 0) {
 			Picker("", selection: $selectedTab) {
@@ -66,11 +71,11 @@ struct ContentView: View {
 						}
 					}
 					.buttonStyle(.borderedProminent)
-					.disabled(!wallpaperManager.isOnline && !wallpaperManager.isRunning)
+					.disabled(!canStartAutoUpdate)
 
 					Button("Update Now") {
 						Task {
-							await wallpaperManager.updateWallpaper()
+							await wallpaperManager.fetchFreshNow()
 						}
 					}
 					.buttonStyle(.borderedProminent)

--- a/Wallhavend/GalleryTab.swift
+++ b/Wallhavend/GalleryTab.swift
@@ -64,11 +64,17 @@ private struct GalleryBucketSection: View {
 
 private struct WallpaperThumbnailView: View {
 	@EnvironmentObject var wallpaperManager: WallpaperManager
+	@EnvironmentObject var wallhavenService: WallhavenService
+
 	let url: URL
 	let bucket: String
 	let isCurrent: Bool
 
 	@State private var nsImage: NSImage?
+
+	private var isPinned: Bool {
+		wallhavenService.pinnedIds.contains(wallpaperManager.wallpaperId(for: url))
+	}
 
 	var body: some View {
 		Group {
@@ -86,11 +92,27 @@ private struct WallpaperThumbnailView: View {
 			RoundedRectangle(cornerRadius: 4)
 				.stroke(Color.red, lineWidth: isCurrent ? 2 : 0)
 		)
+		.overlay(alignment: .topTrailing) {
+			if isPinned {
+				Image(systemName: "pin.fill")
+					.font(.system(size: 9, weight: .bold))
+					.foregroundColor(.white)
+					.padding(3)
+					.background(Circle().fill(Color.accentColor))
+					.padding(3)
+			}
+		}
 		.contentShape(Rectangle())
 		.onTapGesture {
 			Task { await wallpaperManager.applyFromPool(url: url, bucket: bucket) }
 		}
 		.contextMenu {
+			Button(isPinned ? "Unpin" : "Pin") {
+				wallpaperManager.togglePin(url: url)
+			}
+
+			Divider()
+
 			Button("Locate in Finder") {
 				wallpaperManager.revealInFinder(url: url)
 			}

--- a/Wallhavend/StatusBarController.swift
+++ b/Wallhavend/StatusBarController.swift
@@ -48,7 +48,10 @@ class StatusBarController: NSObject, NSMenuDelegate {
 		let autoUpdateTitle = wallpaperManager.isRunning ? "Stop Auto Update" : "Start Auto Update"
 		let autoUpdateItem = NSMenuItem(title: autoUpdateTitle, action: #selector(toggleAutoUpdate), keyEquivalent: "")
 		autoUpdateItem.target = self
-		autoUpdateItem.isEnabled = wallpaperManager.isOnline || wallpaperManager.isRunning
+
+		// Auto-update can run offline in Pinned-only mode (it never downloads).
+		let canRunAutoUpdate = wallpaperManager.isOnline || wallpaperManager.isRunning || wallpaperManager.effectiveRotationMode == .pinnedOnly
+		autoUpdateItem.isEnabled = canRunAutoUpdate
 		menu.addItem(autoUpdateItem)
 
 		menu.addItem(.separator())
@@ -72,7 +75,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
 	@objc
 	private func updateNow() {
 		Task {
-			await wallpaperManager.updateWallpaper()
+			await wallpaperManager.fetchFreshNow()
 		}
 	}
 

--- a/Wallhavend/WallhavenAPI.swift
+++ b/Wallhavend/WallhavenAPI.swift
@@ -75,6 +75,9 @@ class WallhavenService: ObservableObject {
 	@AppStorage("blockedIds")
 	private var blockedIdsRaw: String = ""
 
+	@AppStorage("pinnedIds")
+	private var pinnedIdsRaw: String = ""
+
 	var selectedCategories: Set<WallhavenCategory> {
 		get {
 			Set(selectedCategoriesRaw.split(separator: ",")
@@ -115,6 +118,34 @@ class WallhavenService: ObservableObject {
 		var ids = blockedIds
 		ids.remove(id)
 		blockedIds = ids
+	}
+
+	/// Pinned wallpapers are exempt from pool eviction and form the set cycled by the Pinned-only rotation mode.
+	/// Stored exactly like `blockedIds`: a comma-joined string-set keyed on the wallhaven id (the local filename stem).
+	var pinnedIds: Set<String> {
+		get {
+			Set(pinnedIdsRaw.split(separator: ",")
+				.map {
+					String($0)
+				}
+			)
+		}
+		set {
+			objectWillChange.send()
+			pinnedIdsRaw = newValue.sorted().joined(separator: ",")
+		}
+	}
+
+	func pin(_ id: String) {
+		var ids = pinnedIds
+		ids.insert(id)
+		pinnedIds = ids
+	}
+
+	func unpin(_ id: String) {
+		var ids = pinnedIds
+		ids.remove(id)
+		pinnedIds = ids
 	}
 
 	/// Pure selection step shared by the cache and network paths: drop blocked IDs, then pick the next wallpaper.

--- a/Wallhavend/WallpaperManager+Pool.swift
+++ b/Wallhavend/WallpaperManager+Pool.swift
@@ -9,6 +9,7 @@ extension WallpaperManager {
 
 		let fileManager = FileManager.default
 		let blockedIds = WallhavenService.shared.blockedIds
+		let pinnedIds = WallhavenService.shared.pinnedIds
 		var loadedPools: [String: [URL]] = [:]
 		var loadedCurrent: [String: URL] = [:]
 
@@ -32,7 +33,7 @@ extension WallpaperManager {
 			}
 
 			if !sorted.isEmpty {
-				loadedPools[bucket.rawValue] = Array(sorted.prefix(poolSize))
+				loadedPools[bucket.rawValue] = Self.poolEntries(sorted: sorted, pinnedIds: pinnedIds, poolSize: poolSize)
 				loadedCurrent[bucket.rawValue] = sorted.first
 			}
 		}
@@ -162,7 +163,7 @@ extension WallpaperManager {
 		var list = poolsByBucket[bucket] ?? []
 		list.removeAll { $0 == url }
 		list.insert(url, at: 0)
-		poolsByBucket[bucket] = Array(list.prefix(poolSize))
+		poolsByBucket[bucket] = Self.poolEntries(sorted: list, pinnedIds: WallhavenService.shared.pinnedIds, poolSize: poolSize)
 	}
 
 	func revealInFinder(url: URL) {
@@ -180,11 +181,49 @@ extension WallpaperManager {
 		url.deletingPathExtension().lastPathComponent
 	}
 
+	/// Build the in-memory pool list for a bucket: keep every pinned file, plus the newest `poolSize` non-pinned files.
+	/// Pinned files do not count toward `poolSize` — the target governs only the rotating, non-pinned buffer — so they survive even when `poolSize` is 0. `sorted` must be newest-first; the returned list preserves that order.
+	nonisolated static func poolEntries(sorted: [URL], pinnedIds: Set<String>, poolSize: Int) -> [URL] {
+		var nonPinnedKept = 0
+		var result: [URL] = []
+
+		for url in sorted {
+			let id = url.deletingPathExtension().lastPathComponent
+			if pinnedIds.contains(id) {
+				result.append(url)
+			} else if nonPinnedKept < poolSize {
+				result.append(url)
+				nonPinnedKept += 1
+			}
+		}
+
+		return result
+	}
+
+	/// Pick the next pinned wallpaper to apply in Pinned-only mode: the oldest pinned, non-blocked entry. Pools are newest-first, so that's the last match; applying it moves it to the front, so successive ticks walk the whole pinned set. Returns nil when the bucket has no usable pinned file.
+	nonisolated static func nextPinnedToRotate(pool: [URL], pinnedIds: Set<String>, blockedIds: Set<String>) -> URL? {
+		pool.last {
+			let id = $0.deletingPathExtension().lastPathComponent
+
+			return pinnedIds.contains(id) && !blockedIds.contains(id)
+		}
+	}
+
 	func copyWallhavenURL(for url: URL) {
 		let id = wallpaperId(for: url)
 		let pasteboard = NSPasteboard.general
 		pasteboard.clearContents()
 		pasteboard.setString("https://wallhaven.cc/w/\(id)", forType: .string)
+	}
+
+	/// Flip a wallpaper's pinned state. Pinning protects it from pool eviction and adds it to the Pinned-only rotation set.
+	func togglePin(url: URL) {
+		let id = wallpaperId(for: url)
+		if WallhavenService.shared.pinnedIds.contains(id) {
+			WallhavenService.shared.unpin(id)
+		} else {
+			WallhavenService.shared.pin(id)
+		}
 	}
 
 	/// What to do after a wallpaper is blocked, given whether it was the current one and what's left in the bucket's pool.
@@ -225,6 +264,7 @@ extension WallpaperManager {
 		}
 
 		WallhavenService.shared.block(id)
+		WallhavenService.shared.unpin(id)
 		evictFromPool(id: id)
 
 		for bucket in affectedBuckets {
@@ -270,6 +310,7 @@ extension WallpaperManager {
 		do {
 			let storageURL = try getWallpaperStorageDirectory()
 			let fileManager = FileManager.default
+			let pinnedIds = WallhavenService.shared.pinnedIds
 
 			var toKeep = Set<URL>()
 			for list in poolsByBucket.values {
@@ -286,6 +327,11 @@ extension WallpaperManager {
 					let files = try? fileManager.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
 				else {
 					continue
+				}
+
+				for file in files where pinnedIds.contains(wallpaperId(for: file)) {
+					// Pinned files are exempt from cleanup, even when poolSize is 0 ("apply and forget").
+					toKeep.insert(file.standardized)
 				}
 
 				for file in files where !toKeep.contains(file.standardized) {

--- a/Wallhavend/WallpaperManager+Pool.swift
+++ b/Wallhavend/WallpaperManager+Pool.swift
@@ -182,7 +182,7 @@ extension WallpaperManager {
 	}
 
 	/// Build the in-memory pool list for a bucket: keep every pinned file, plus the newest `poolSize` non-pinned files.
-	/// Pinned files do not count toward `poolSize` — the target governs only the rotating, non-pinned buffer — so they survive even when `poolSize` is 0. `sorted` must be newest-first; the returned list preserves that order.
+	/// Pinned files do not count toward `poolSize` — the target governs only the rotating, non-pinned buffer — so they survive regardless of how small `poolSize` is. `sorted` must be newest-first; the returned list preserves that order.
 	nonisolated static func poolEntries(sorted: [URL], pinnedIds: Set<String>, poolSize: Int) -> [URL] {
 		var nonPinnedKept = 0
 		var result: [URL] = []
@@ -330,7 +330,7 @@ extension WallpaperManager {
 				}
 
 				for file in files where pinnedIds.contains(wallpaperId(for: file)) {
-					// Pinned files are exempt from cleanup, even when poolSize is 0 ("apply and forget").
+					// Pinned files are exempt from cleanup, even at the minimum pool size ("apply and forget").
 					toKeep.insert(file.standardized)
 				}
 

--- a/Wallhavend/WallpaperManager+Wallpaper.swift
+++ b/Wallhavend/WallpaperManager+Wallpaper.swift
@@ -2,13 +2,52 @@ import Foundation
 import AppKit
 
 extension WallpaperManager {
+	/// The automatic rotation tick. In `.fresh` mode it fetches fresh online and rotates the pool offline; in `.pinnedOnly` it never downloads and cycles only the pinned set (so it works offline too).
 	func updateWallpaper() async {
 		error = nil
 
+		guard let screensByBucket = currentScreensByBucket() else {
+			return
+		}
+
+		switch effectiveRotationMode {
+			case .fresh:
+				await runFreshUpdate(screensByBucket: screensByBucket)
+			case .pinnedOnly:
+				await runPinnedUpdate(screensByBucket: screensByBucket)
+		}
+	}
+
+	/// Manual "Update Now": always fetch a fresh wallpaper, regardless of rotation mode (the button is gated to online-only). This is the on-demand "casual blend" the issue settled on — fetch fresh, pin it if you like it — that keeps Pinned-only useful.
+	func fetchFreshNow() async {
+		error = nil
+
+		guard let screensByBucket = currentScreensByBucket() else {
+			return
+		}
+
+		await runFreshUpdate(screensByBucket: screensByBucket)
+	}
+
+	/// Run the normal update for a single bucket, respecting the current rotation mode (used by the block-replacement fallback).
+	func updateBucket(_ bucket: AspectBucket, screens: [NSScreen]) async {
+		switch effectiveRotationMode {
+			case .fresh:
+				if isOnline {
+					await updateWallpaperForBucket(bucket: bucket, screens: screens)
+				} else {
+					await rotatePoolForBucket(bucket: bucket, screens: screens)
+				}
+			case .pinnedOnly:
+				await rotatePinnedForBucket(bucket: bucket, screens: screens)
+		}
+	}
+
+	private func currentScreensByBucket() -> [AspectBucket: [NSScreen]]? {
 		let screens = NSScreen.screens
 		guard !screens.isEmpty else {
 			print("No screens detected. Skipping update.")
-			return
+			return nil
 		}
 
 		var screensByBucket: [AspectBucket: [NSScreen]] = [:]
@@ -17,6 +56,11 @@ extension WallpaperManager {
 			screensByBucket[bucket, default: []].append(screen)
 		}
 
+		return screensByBucket
+	}
+
+	/// Fetch fresh per bucket when online; rotate the saved pool per bucket when offline (a no-op when the pool is empty).
+	private func runFreshUpdate(screensByBucket: [AspectBucket: [NSScreen]]) async {
 		if isOnline {
 			await withTaskGroup(of: Void.self) { group in
 				for (bucket, bucketScreens) in screensByBucket {
@@ -32,12 +76,10 @@ extension WallpaperManager {
 		}
 	}
 
-	/// Run the normal update for a single bucket, respecting connectivity: fetch fresh when online, otherwise rotate the pool (a no-op when the pool is empty).
-	func updateBucket(_ bucket: AspectBucket, screens: [NSScreen]) async {
-		if isOnline {
-			await updateWallpaperForBucket(bucket: bucket, screens: screens)
-		} else {
-			await rotatePoolForBucket(bucket: bucket, screens: screens)
+	/// Cycle the pinned set per bucket, never downloading. Buckets with no usable pinned file are skipped.
+	private func runPinnedUpdate(screensByBucket: [AspectBucket: [NSScreen]]) async {
+		for (bucket, bucketScreens) in screensByBucket {
+			await rotatePinnedForBucket(bucket: bucket, screens: bucketScreens)
 		}
 	}
 
@@ -91,6 +133,33 @@ extension WallpaperManager {
 			currentByBucket[bucket.rawValue] = oldest
 			lastUpdated = Date()
 			print("Rotated pool wallpaper for \(bucket.rawValue): \(oldest.lastPathComponent)")
+		} catch {
+			self.error = "Failed to apply wallpaper: \(error.localizedDescription)"
+		}
+	}
+
+	/// Pinned-only rotation for a single bucket: apply the oldest usable pinned wallpaper, never downloading. A no-op when the bucket has no pinned file — Pinned-only honors "never download" rather than falling back to a fetch.
+	@MainActor
+	private func rotatePinnedForBucket(bucket: AspectBucket, screens: [NSScreen]) async {
+		let pinnedIds = WallhavenService.shared.pinnedIds
+		let blockedIds = WallhavenService.shared.blockedIds
+
+		guard
+			let list = poolsByBucket[bucket.rawValue],
+			let target = Self.nextPinnedToRotate(pool: list, pinnedIds: pinnedIds, blockedIds: blockedIds)
+		else {
+			print("Pinned-only and no pinned wallpaper for \(bucket.rawValue). Skipping.")
+			return
+		}
+
+		do {
+			error = nil
+			try applyWallpaper(url: target, to: screens)
+
+			prependToPool(url: target, bucket: bucket.rawValue)
+			currentByBucket[bucket.rawValue] = target
+			lastUpdated = Date()
+			print("Rotated pinned wallpaper for \(bucket.rawValue): \(target.lastPathComponent)")
 		} catch {
 			self.error = "Failed to apply wallpaper: \(error.localizedDescription)"
 		}

--- a/Wallhavend/WallpaperManager+Wallpaper.swift
+++ b/Wallhavend/WallpaperManager+Wallpaper.swift
@@ -126,6 +126,11 @@ extension WallpaperManager {
 			return
 		}
 
+		guard oldest != currentByBucket[bucket.rawValue] else {
+			print("Offline and the only usable pool wallpaper for \(bucket.rawValue) is already current. Skipping.")
+			return
+		}
+
 		do {
 			error = nil
 			try applyWallpaper(url: oldest, to: screens)

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -2,6 +2,27 @@ import Foundation
 import AppKit
 import Combine
 
+/// How automatic rotation picks the next wallpaper.
+///
+/// macOS has no wifi-only axis (the Android sibling's middle option) — rotation is already auto-gated on online/offline — so the source axis collapses to two real states. The network rule stays automatic within `.fresh`.
+enum RotationMode: String, CaseIterable, Identifiable {
+	/// Download fresh when online; rotate the saved pool when offline (the historical behavior).
+	case fresh
+	/// Never download — cycle only the pinned set. Works offline; the manual "Update Now" still fetches fresh.
+	case pinnedOnly = "pinned_only"
+
+	var id: String { rawValue }
+
+	var label: String {
+		switch self {
+			case .fresh:
+				return "Fresh"
+			case .pinnedOnly:
+				return "Pinned only"
+		}
+	}
+}
+
 @MainActor
 class WallpaperManager: ObservableObject {
 	static let shared = WallpaperManager()
@@ -19,6 +40,11 @@ class WallpaperManager: ObservableObject {
 	init() {
 		let stored = UserDefaults.standard.object(forKey: "poolSize") as? Int ?? 10
 		_poolSize = Published(initialValue: stored)
+
+		let storedMode = UserDefaults.standard.string(forKey: "rotationMode")
+			.flatMap(RotationMode.init(rawValue:)) ?? .fresh
+
+		_rotationMode = Published(initialValue: storedMode)
 
 		setupSessionObservers()
 		setupNetworkObserver()
@@ -39,6 +65,21 @@ class WallpaperManager: ObservableObject {
 	@Published var poolSize: Int = 10 {
 		didSet {
 			UserDefaults.standard.set(poolSize, forKey: "poolSize")
+		}
+	}
+
+	@Published var rotationMode: RotationMode = .fresh {
+		didSet {
+			UserDefaults.standard.set(rotationMode.rawValue, forKey: "rotationMode")
+		}
+	}
+
+	/// The rotation mode the engine actually uses. Pinned-only with zero pins is a dead state (never downloads, nothing to cycle), so it falls back to `.fresh` — matching what the settings picker shows when no pins exist.
+	var effectiveRotationMode: RotationMode {
+		if rotationMode == .pinnedOnly && WallhavenService.shared.pinnedIds.isEmpty {
+			return .fresh
+		} else {
+			return rotationMode
 		}
 	}
 

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -39,7 +39,13 @@ class WallpaperManager: ObservableObject {
 
 	init() {
 		let stored = UserDefaults.standard.object(forKey: "poolSize") as? Int ?? 10
-		_poolSize = Published(initialValue: stored)
+		// "Current only" used to be 0; it's now 1 so the current wallpaper shows in the gallery. Migrate any persisted 0.
+		let migratedPoolSize = stored == 0 ? 1 : stored
+		if migratedPoolSize != stored {
+			UserDefaults.standard.set(migratedPoolSize, forKey: "poolSize")
+		}
+
+		_poolSize = Published(initialValue: migratedPoolSize)
 
 		let storedMode = UserDefaults.standard.string(forKey: "rotationMode")
 			.flatMap(RotationMode.init(rawValue:)) ?? .fresh

--- a/WallhavendTests/PinTests.swift
+++ b/WallhavendTests/PinTests.swift
@@ -18,6 +18,15 @@ final class PinTests: XCTestCase {
 		XCTAssertEqual(result, [url("a"), url("b")])
 	}
 
+	func testPoolEntriesKeepsOnlyNewestWhenPoolSizeOne() {
+		// "Current only" is poolSize 1: keep just the newest (current) non-pinned wallpaper.
+		let sorted = [url("a"), url("b"), url("c")]
+
+		let result = WallpaperManager.poolEntries(sorted: sorted, pinnedIds: [], poolSize: 1)
+
+		XCTAssertEqual(result, [url("a")])
+	}
+
 	func testPoolEntriesKeepsPinnedBeyondPoolSizeAndPreservesOrder() {
 		// Newest-first, with two pinned entries past the non-pinned window.
 		let sorted = [url("n1"), url("p1"), url("n2"), url("n3"), url("p2")]

--- a/WallhavendTests/PinTests.swift
+++ b/WallhavendTests/PinTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import Wallhavend
+
+@MainActor
+final class PinTests: XCTestCase {
+	/// A pool URL whose filename stem is the wallhaven id (see `WallpaperManager.wallpaperId(for:)`).
+	private func url(_ id: String) -> URL {
+		URL(fileURLWithPath: "/tmp/16x9/\(id).jpg")
+	}
+
+	// MARK: - poolEntries: pinned files survive trimming
+
+	func testPoolEntriesCapsNonPinnedToPoolSize() {
+		let sorted = [url("a"), url("b"), url("c"), url("d")]
+
+		let result = WallpaperManager.poolEntries(sorted: sorted, pinnedIds: [], poolSize: 2)
+
+		XCTAssertEqual(result, [url("a"), url("b")])
+	}
+
+	func testPoolEntriesKeepsPinnedBeyondPoolSizeAndPreservesOrder() {
+		// Newest-first, with two pinned entries past the non-pinned window.
+		let sorted = [url("n1"), url("p1"), url("n2"), url("n3"), url("p2")]
+
+		let result = WallpaperManager.poolEntries(sorted: sorted, pinnedIds: ["p1", "p2"], poolSize: 1)
+
+		// Keeps the single newest non-pinned (n1) plus both pinned, in their original order.
+		XCTAssertEqual(result, [url("n1"), url("p1"), url("p2")])
+	}
+
+	func testPoolEntriesKeepsPinnedWhenPoolSizeZero() {
+		let sorted = [url("n1"), url("p1"), url("n2")]
+
+		let result = WallpaperManager.poolEntries(sorted: sorted, pinnedIds: ["p1"], poolSize: 0)
+
+		XCTAssertEqual(result, [url("p1")])
+	}
+
+	func testPoolEntriesEmptyWhenNothingPinnedAndPoolSizeZero() {
+		let sorted = [url("n1"), url("n2")]
+
+		let result = WallpaperManager.poolEntries(sorted: sorted, pinnedIds: [], poolSize: 0)
+
+		XCTAssertTrue(result.isEmpty)
+	}
+
+	// MARK: - nextPinnedToRotate: cycle only the pinned set
+
+	func testNextPinnedPicksOldestPinned() {
+		// Pools are newest-first, so "oldest pinned" is the last pinned entry.
+		let pool = [url("pNew"), url("nonPinned"), url("pOld")]
+
+		let result = WallpaperManager.nextPinnedToRotate(pool: pool, pinnedIds: ["pNew", "pOld"], blockedIds: [])
+
+		XCTAssertEqual(result, url("pOld"))
+	}
+
+	func testNextPinnedSkipsBlockedPinnedStraggler() {
+		// The oldest pinned entry is also blocked, so the next-newest usable pinned one wins.
+		let pool = [url("pUsable"), url("pBlocked")]
+
+		let result = WallpaperManager.nextPinnedToRotate(pool: pool, pinnedIds: ["pUsable", "pBlocked"], blockedIds: ["pBlocked"])
+
+		XCTAssertEqual(result, url("pUsable"))
+	}
+
+	func testNextPinnedIgnoresNonPinnedEntries() {
+		let pool = [url("a"), url("pinned"), url("b")]
+
+		let result = WallpaperManager.nextPinnedToRotate(pool: pool, pinnedIds: ["pinned"], blockedIds: [])
+
+		XCTAssertEqual(result, url("pinned"))
+	}
+
+	func testNextPinnedReturnsNilWhenNoneArePinned() {
+		let pool = [url("a"), url("b")]
+
+		let result = WallpaperManager.nextPinnedToRotate(pool: pool, pinnedIds: [], blockedIds: [])
+
+		XCTAssertNil(result)
+	}
+
+	// MARK: - Persistence round-tripping through UserDefaults
+
+	func testPinUnpinRoundTripsThroughUserDefaults() {
+		let service = WallhavenService.shared
+		let saved = UserDefaults.standard.string(forKey: "pinnedIds")
+		defer { UserDefaults.standard.set(saved, forKey: "pinnedIds") }
+
+		service.pinnedIds = []
+		service.pin("abc123")
+		service.pin("def456")
+
+		XCTAssertEqual(service.pinnedIds, ["abc123", "def456"])
+
+		// The raw string in UserDefaults is comma-joined and survives a fresh read.
+		let raw = UserDefaults.standard.string(forKey: "pinnedIds")
+		XCTAssertEqual(raw, "abc123,def456")
+
+		service.unpin("abc123")
+		XCTAssertEqual(service.pinnedIds, ["def456"])
+		XCTAssertEqual(UserDefaults.standard.string(forKey: "pinnedIds"), "def456")
+	}
+
+	func testPinningSameIdTwiceIsIdempotent() {
+		let service = WallhavenService.shared
+		let saved = UserDefaults.standard.string(forKey: "pinnedIds")
+		defer { UserDefaults.standard.set(saved, forKey: "pinnedIds") }
+
+		service.pinnedIds = []
+		service.pin("dupe")
+		service.pin("dupe")
+
+		XCTAssertEqual(service.pinnedIds, ["dupe"])
+	}
+}


### PR DESCRIPTION
Ports Attacktive/Wallhavend-android#66 to the macOS app: pin wallpapers, and a Pinned-only rotation mode.

## Pinning (mirrors the existing blocklist)
- `WallhavenService` gains a `pinnedIds` string-set with `pin`/`unpin`.
- Gallery context-menu **Pin/Unpin** plus a pin badge on pinned thumbnails.
- Pinned files are exempt from pool eviction — `poolEntries` keeps every pinned file plus the newest `poolSize` non-pinned files, and cleanup keeps pinned files even at the minimum pool size. Pinned files do not count toward `poolSize` (governs only the rotating buffer).
- Blocking a wallpaper now also unpins it, so there's never a contradictory blocked-and-pinned id.

## Rotation mode
- New `RotationMode` enum (**Fresh** / **Pinned only**) with a radio picker in **Advanced**.
- **Pinned only** never downloads and cycles only the pinned set per aspect bucket; works offline.
- Manual **Update Now** always fetches fresh regardless of mode (the on-demand "casual blend").
- `effectiveRotationMode` falls back to Fresh when there are no pins, so the engine never sits in a dead pinned-only-with-zero-pins state; the picker also disables Pinned-only until at least one pin exists.

### Why 2-way instead of the Android 3-way
The macOS app has no wifi-only setting — rotation is already auto-gated on online/offline — so the source axis collapses to two real states. No `wifiOnly` migration is needed (it never existed here).

## Pool size: "Current only" now keeps 1
- The "Current only" option was `0` (empty rotating buffer), which kept the current wallpaper out of the Gallery — so it couldn't be pinned/blocked/located there. It's now `1`, so the current wallpaper shows as a single gallery item and is actionable. This pairs naturally with pinning above.
- A persisted `poolSize` of `0` is migrated to `1` on launch (an absent `0` tag would otherwise leave the segmented picker with nothing selected).
- Offline rotation now skips re-applying the wallpaper that's already current, so `poolSize = 1` behaves like the old `0` offline (no timestamp churn); the only visible change is the gallery item.

## Tests
New `PinTests` cover pin/unpin persistence, `poolEntries` (pinned survive trimming; `poolSize` of `0` and `1`), and `nextPinnedToRotate`. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)