### PR TITLE
bugfix: enable Sparkle automatic update checks

### DIFF
--- a/Wallhavend/Info.plist
+++ b/Wallhavend/Info.plist
@@ -28,5 +28,9 @@
 	<string>https://github.com/Attacktive/Wallhavend/releases/latest/download/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>FtiRFqJYMaaGBpSP9PamY4D4SMoiV5AXzSj4CSdDzbU=</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUAutomaticallyUpdate</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

Wallhavend wires up Sparkle (`SPUStandardUpdaterController(startingUpdater: true)`) but never opts into **automatic** update checking — so it only updated when you manually chose "Check for Updates…". It never checked on its own.

**Root cause:** the updater leaves automatic checking at Sparkle's default, which is opt-in via a first-run *"Check for Updates automatically?"* permission prompt. In an `LSUIElement` / `.accessory` menu-bar agent with no dock presence, that prompt never effectively surfaces, and there's no in-app toggle — so `automaticallyChecksForUpdates` stayed `false` forever. Manual checks always worked because they bypass that flag.

**Fix:** declare the behavior in `Info.plist` rather than relying on the prompt:
- `SUEnableAutomaticChecks = true` — schedule automatic checks (Sparkle's default ~1-day interval)
- `SUAutomaticallyUpdate = true` — download + install updates in the background

Confirmed the keys survive Xcode's Info.plist processing and land in the built app bundle, and the app builds clean.

Note: existing users won't *auto*-receive this fix — they'll need one final manual update, after which automatic updates work going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
