### PR TITLE
Pin the current wallpaper from the menu bar, and clarify the update label

### DIFF
--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -73,7 +73,7 @@ struct ContentView: View {
 					.buttonStyle(.borderedProminent)
 					.disabled(!canStartAutoUpdate)
 
-					Button("Update Now") {
+					Button("Update Wallpaper Now") {
 						Task {
 							await wallpaperManager.fetchFreshNow()
 						}

--- a/Wallhavend/StatusBarController.swift
+++ b/Wallhavend/StatusBarController.swift
@@ -40,7 +40,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
 			menu.addItem(.separator())
 		}
 
-		let updateNowItem = NSMenuItem(title: "Update Now", action: #selector(updateNow), keyEquivalent: "")
+		let updateNowItem = NSMenuItem(title: "Update Wallpaper Now", action: #selector(updateNow), keyEquivalent: "")
 		updateNowItem.target = self
 		updateNowItem.isEnabled = wallpaperManager.isOnline
 		menu.addItem(updateNowItem)

--- a/Wallhavend/StatusBarController.swift
+++ b/Wallhavend/StatusBarController.swift
@@ -45,6 +45,32 @@ class StatusBarController: NSObject, NSMenuDelegate {
 		updateNowItem.isEnabled = wallpaperManager.isOnline
 		menu.addItem(updateNowItem)
 
+		let pinAction = wallpaperManager.currentPinAction
+		let pinTitle: String
+		let pinSymbol: String
+		let pinSelector: Selector?
+
+		switch pinAction {
+			case .unavailable:
+				pinTitle = "Pin Current Wallpaper"
+				pinSymbol = "pin"
+				pinSelector = nil
+			case .pin:
+				pinTitle = "Pin Current Wallpaper"
+				pinSymbol = "pin"
+				pinSelector = #selector(togglePinCurrentWallpaper)
+			case .unpin:
+				pinTitle = "Unpin Current Wallpaper"
+				pinSymbol = "pin.slash"
+				pinSelector = #selector(togglePinCurrentWallpaper)
+		}
+
+		let pinItem = NSMenuItem(title: pinTitle, action: pinSelector, keyEquivalent: "")
+		pinItem.target = self
+		pinItem.isEnabled = pinAction != .unavailable
+		pinItem.image = NSImage(systemSymbolName: pinSymbol, accessibilityDescription: nil)
+		menu.addItem(pinItem)
+
 		let autoUpdateTitle = wallpaperManager.isRunning ? "Stop Auto Update" : "Start Auto Update"
 		let autoUpdateItem = NSMenuItem(title: autoUpdateTitle, action: #selector(toggleAutoUpdate), keyEquivalent: "")
 		autoUpdateItem.target = self
@@ -77,6 +103,11 @@ class StatusBarController: NSObject, NSMenuDelegate {
 		Task {
 			await wallpaperManager.fetchFreshNow()
 		}
+	}
+
+	@objc
+	private func togglePinCurrentWallpaper() {
+		wallpaperManager.toggleCurrentWallpaperPin()
 	}
 
 	@objc

--- a/Wallhavend/WallpaperManager+Pool.swift
+++ b/Wallhavend/WallpaperManager+Pool.swift
@@ -230,8 +230,10 @@ extension WallpaperManager {
 	enum CurrentPinAction: Equatable {
 		/// Nothing on screen is a managed gallery wallpaper — the menu item is shown disabled.
 		case unavailable
+
 		/// At least one on-screen gallery wallpaper isn't pinned — the item reads "Pin Current Wallpaper" and pins them all.
 		case pin
+
 		/// Every on-screen gallery wallpaper is already pinned — the item reads "Unpin Current Wallpaper" and unpins them all.
 		case unpin
 	}

--- a/Wallhavend/WallpaperManager+Pool.swift
+++ b/Wallhavend/WallpaperManager+Pool.swift
@@ -226,6 +226,78 @@ extension WallpaperManager {
 		}
 	}
 
+	/// The menu-bar pin toggle's three states, derived from the wallpaper(s) actually on screen, restricted to gallery (pool) members.
+	enum CurrentPinAction: Equatable {
+		/// Nothing on screen is a managed gallery wallpaper — the menu item is shown disabled.
+		case unavailable
+		/// At least one on-screen gallery wallpaper isn't pinned — the item reads "Pin Current Wallpaper" and pins them all.
+		case pin
+		/// Every on-screen gallery wallpaper is already pinned — the item reads "Unpin Current Wallpaper" and unpins them all.
+		case unpin
+	}
+
+	/// Decide what the "Pin Current Wallpaper" menu item should do, given the ids on screen, the gallery's pool ids, and the pinned set.
+	/// Only pool members are pinnable, so an on-screen wallpaper this instance doesn't manage (or hasn't loaded) is ignored — a stale or foreign desktop image can't be pinned.
+	/// Unpin only when *every* pinnable current is already pinned.
+	nonisolated static func pinAction(currentIds: [String], poolIds: Set<String>, pinnedIds: Set<String>) -> CurrentPinAction {
+		let pinnable = currentIds.filter { poolIds.contains($0) }
+
+		guard !pinnable.isEmpty else {
+			return .unavailable
+		}
+
+		return if pinnable.allSatisfy({ pinnedIds.contains($0) }) {
+			.unpin
+		} else {
+			.pin
+		}
+	}
+
+	/// The wallpapers actually on screen right now, read from the system per display, de-duplicated across screens.
+	/// This is the live desktop — not the app's internal record, which can be stale or reflect a wallpaper set by another instance.
+	var currentWallpaperURLs: [URL] {
+		var seen = Set<URL>()
+
+		return NSScreen.screens
+			.compactMap { NSWorkspace.shared.desktopImageURL(for: $0) }
+			.filter { seen.insert($0).inserted }
+	}
+
+	/// Every wallpaper id present in the in-memory pool (i.e. shown in the Gallery), across all buckets.
+	var poolWallpaperIds: Set<String> {
+		Set(poolsByBucket.values.flatMap { $0 }.map { wallpaperId(for: $0) })
+	}
+
+	/// The pin action for whatever is actually on screen now, restricted to gallery members — drives the menu item's title, enabled state, and behavior.
+	var currentPinAction: CurrentPinAction {
+		Self.pinAction(
+			currentIds: currentWallpaperURLs.map { wallpaperId(for: $0) },
+			poolIds: poolWallpaperIds,
+			pinnedIds: WallhavenService.shared.pinnedIds
+		)
+	}
+
+	/// Pin every on-screen gallery wallpaper, or unpin them all when they're already pinned — the menu-bar counterpart to the Gallery's per-item pin.
+	/// On-screen wallpapers not in the gallery are ignored; it's a no-op when none are.
+	func toggleCurrentWallpaperPin() {
+		let poolIds = poolWallpaperIds
+		let currentIds = currentWallpaperURLs.map { wallpaperId(for: $0) }
+		let pinnable = currentIds.filter { poolIds.contains($0) }
+		let action = Self.pinAction(currentIds: currentIds, poolIds: poolIds, pinnedIds: WallhavenService.shared.pinnedIds)
+
+		guard action != .unavailable else {
+			return
+		}
+
+		for id in pinnable {
+			if action == .unpin {
+				WallhavenService.shared.unpin(id)
+			} else {
+				WallhavenService.shared.pin(id)
+			}
+		}
+	}
+
 	/// What to do after a wallpaper is blocked, given whether it was the current one and what's left in the bucket's pool.
 	enum BlockReplacementAction: Equatable {
 		case doNothing

--- a/Wallhavend/WallpaperManager+Wallpaper.swift
+++ b/Wallhavend/WallpaperManager+Wallpaper.swift
@@ -18,7 +18,8 @@ extension WallpaperManager {
 		}
 	}
 
-	/// Manual "Update Now": always fetch a fresh wallpaper, regardless of rotation mode (the button is gated to online-only). This is the on-demand "casual blend" the issue settled on — fetch fresh, pin it if you like it — that keeps Pinned-only useful.
+	/// Manual "Update Wallpaper Now": always fetch a fresh wallpaper, regardless of rotation mode (the button is gated to online-only).
+	/// This is the on-demand "casual blend" the issue settled on — fetch fresh, pin it if you like it — that keeps Pinned-only useful.
 	func fetchFreshNow() async {
 		error = nil
 

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -8,7 +8,9 @@ import Combine
 enum RotationMode: String, CaseIterable, Identifiable {
 	/// Download fresh when online; rotate the saved pool when offline (the historical behavior).
 	case fresh
-	/// Never download — cycle only the pinned set. Works offline; the manual "Update Now" still fetches fresh.
+
+	/// Never download — cycle only the pinned set.
+	/// Works offline; the manual "Update Wallpaper Now" still fetches fresh.
 	case pinnedOnly = "pinned_only"
 
 	var id: String { rawValue }

--- a/WallhavendTests/PinTests.swift
+++ b/WallhavendTests/PinTests.swift
@@ -89,6 +89,60 @@ final class PinTests: XCTestCase {
 		XCTAssertNil(result)
 	}
 
+	// MARK: - pinAction: the menu-bar toggle decision (gated to gallery/pool members)
+
+	func testPinActionUnavailableWhenNothingOnScreen() {
+		let result = WallpaperManager.pinAction(currentIds: [], poolIds: ["a"], pinnedIds: ["a"])
+
+		XCTAssertEqual(result, .unavailable)
+	}
+
+	func testPinActionUnavailableWhenCurrentNotInPool() {
+		// The wallpaper on screen isn't in this instance's gallery (e.g. set by another instance), so it can't be pinned.
+		let result = WallpaperManager.pinAction(currentIds: ["x"], poolIds: ["a"], pinnedIds: [])
+
+		XCTAssertEqual(result, .unavailable)
+	}
+
+	func testPinActionPinsWhenSingleCurrentInPoolNotPinned() {
+		let result = WallpaperManager.pinAction(currentIds: ["a"], poolIds: ["a"], pinnedIds: [])
+
+		XCTAssertEqual(result, .pin)
+	}
+
+	func testPinActionUnpinsWhenSingleCurrentAlreadyPinned() {
+		let result = WallpaperManager.pinAction(currentIds: ["a"], poolIds: ["a"], pinnedIds: ["a"])
+
+		XCTAssertEqual(result, .unpin)
+	}
+
+	func testPinActionUnpinsOnlyWhenEveryInPoolCurrentIsPinned() {
+		let result = WallpaperManager.pinAction(currentIds: ["a", "b"], poolIds: ["a", "b"], pinnedIds: ["a", "b"])
+
+		XCTAssertEqual(result, .unpin)
+	}
+
+	func testPinActionPinsWhenInPoolCurrentsAreMixed() {
+		// Both on-screen wallpapers are in the pool but only one is pinned, so the action pins the straggler too.
+		let result = WallpaperManager.pinAction(currentIds: ["a", "b"], poolIds: ["a", "b"], pinnedIds: ["a"])
+
+		XCTAssertEqual(result, .pin)
+	}
+
+	func testPinActionIgnoresOnScreenWallpapersNotInPool() {
+		// "x" is on screen but not in the gallery; only the in-pool "a" counts, and it's unpinned, so the action pins.
+		let result = WallpaperManager.pinAction(currentIds: ["a", "x"], poolIds: ["a"], pinnedIds: [])
+
+		XCTAssertEqual(result, .pin)
+	}
+
+	func testPinActionUnpinsWhenOnlyInPoolCurrentIsPinnedAndOthersAreForeign() {
+		// "x" (not in pool) is ignored; the only pinnable current "a" is already pinned, so the action unpins.
+		let result = WallpaperManager.pinAction(currentIds: ["a", "x"], poolIds: ["a"], pinnedIds: ["a"])
+
+		XCTAssertEqual(result, .unpin)
+	}
+
 	// MARK: - Persistence round-tripping through UserDefaults
 
 	func testPinUnpinRoundTripsThroughUserDefaults() {


### PR DESCRIPTION
## Pin the current wallpaper (menu bar)

Adds a **Pin Current Wallpaper** / **Unpin Current Wallpaper** toggle to the status-bar menu, below Update. It acts on whatever is *actually* on screen — read live per display via `NSWorkspace.desktopImageURL` — and only on wallpapers present in the Gallery, so a stale or externally-set wallpaper (e.g. from a second running instance) can't be pinned. On multi-monitor it pins/unpins all current wallpapers at once, and the item is disabled when nothing on screen is a Gallery member.

Pinning reuses the existing `pinnedIds` set, so it inherits the cleanup/eviction exemption and feeds Pinned-only rotation. The pure decision (`pinAction`) is unit-tested.

## Clarify the update label — Closes #71

**Update Now** was ambiguous next to **Check for Updates…**; it now reads **Update Wallpaper Now** in the menu and the settings button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)