### PR TITLE
Pause Pinned-only rotation when nothing is pinned and warn in the UI

### DIFF
--- a/Wallhavend.xcodeproj/project.pbxproj
+++ b/Wallhavend.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		AA0000012F600000000REPL1 /* AutoReplaceOnBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000REPL1 /* AutoReplaceOnBlockTests.swift */; };
 		AA0000012F600000000PINT1 /* PinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000PINT1 /* PinTests.swift */; };
 		AA0000012F600000000PRET1 /* PrefetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000PRET1 /* PrefetchTests.swift */; };
+		AA0000012F600000000ROTM1 /* RotationModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000ROTM1 /* RotationModeTests.swift */; };
 		AA0000012F600000000POOL1 /* WallpaperManager+Pool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000POOL1 /* WallpaperManager+Pool.swift */; };
 		AA0000012F600000000WALL1 /* WallpaperManager+Wallpaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */; };
 		AA0000012F600000000PREF1 /* WallpaperManager+Prefetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000PREF1 /* WallpaperManager+Prefetch.swift */; };
@@ -56,6 +57,7 @@
 		AA0000002F600000000REPL1 /* AutoReplaceOnBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoReplaceOnBlockTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000PINT1 /* PinTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000PRET1 /* PrefetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefetchTests.swift; sourceTree = "<group>"; };
+		AA0000002F600000000ROTM1 /* RotationModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationModeTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000POOL1 /* WallpaperManager+Pool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Pool.swift"; sourceTree = "<group>"; };
 		AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Wallpaper.swift"; sourceTree = "<group>"; };
 		AA0000002F600000000PREF1 /* WallpaperManager+Prefetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Prefetch.swift"; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 				AA0000002F600000000REPL1 /* AutoReplaceOnBlockTests.swift */,
 				AA0000002F600000000PINT1 /* PinTests.swift */,
 				AA0000002F600000000PRET1 /* PrefetchTests.swift */,
+				AA0000002F600000000ROTM1 /* RotationModeTests.swift */,
 				D0ED74A92DCB72F90008C397 /* WallhavendTests.swift */,
 			);
 			path = WallhavendTests;
@@ -300,6 +303,7 @@
 				AA0000012F600000000REPL1 /* AutoReplaceOnBlockTests.swift in Sources */,
 				AA0000012F600000000PINT1 /* PinTests.swift in Sources */,
 				AA0000012F600000000PRET1 /* PrefetchTests.swift in Sources */,
+				AA0000012F600000000ROTM1 /* RotationModeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Wallhavend/AdvancedTab.swift
+++ b/Wallhavend/AdvancedTab.swift
@@ -22,19 +22,33 @@ struct AdvancedTab: View {
 		!wallhavenService.pinnedIds.isEmpty
 	}
 
+	/// Shows the stored mode as-is; the setter still refuses to enter Pinned only while nothing is pinned (the radio option is disabled then, too).
 	private var rotationModeBinding: Binding<RotationMode> {
 		Binding(
-			get: { hasPins ? wallpaperManager.rotationMode : .fresh },
-			set: { wallpaperManager.rotationMode = ($0 == .pinnedOnly && !hasPins) ? .fresh : $0 }
+			get: { wallpaperManager.rotationMode },
+			set: { newMode in
+				wallpaperManager.rotationMode = if newMode == .pinnedOnly && !hasPins {
+					.fresh
+				} else {
+					newMode
+				}
+			}
 		)
 	}
 
-	private var rotationCaption: String {
+	/// The caption under the Rotation picker. Pins exist: explain both modes. Nothing pinned with Fresh stored: hint how to enable Pinned only. Nothing pinned with Pinned only stored: warn that scheduled updates are paused.
+	static func rotationCaption(storedMode: RotationMode, hasPins: Bool) -> String {
 		if hasPins {
 			return "Fresh downloads new wallpapers (and rotates your pool when offline). Pinned only never downloads — it cycles just your pinned wallpapers. “Update Now” always fetches a fresh one."
+		} else if storedMode == .pinnedOnly {
+			return "Pinned only never downloads, and nothing is pinned — automatic updates are paused. Pin a wallpaper or switch to Fresh. “Update Now” still fetches a fresh one."
 		} else {
 			return "Fresh downloads new wallpapers (and rotates your pool when offline). Pin a wallpaper to enable Pinned only."
 		}
+	}
+
+	private var rotationCaption: String {
+		Self.rotationCaption(storedMode: wallpaperManager.rotationMode, hasPins: hasPins)
 	}
 
 	var body: some View {

--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
 
 	/// Auto-update can run offline in Pinned-only mode (it never downloads), so don't gate it on connectivity there.
 	private var canStartAutoUpdate: Bool {
-		wallpaperManager.isOnline || wallpaperManager.isRunning || wallpaperManager.effectiveRotationMode == .pinnedOnly
+		wallpaperManager.isOnline || wallpaperManager.isRunning || wallpaperManager.rotationMode == .pinnedOnly
 	}
 
 	var body: some View {

--- a/Wallhavend/StatusBarController.swift
+++ b/Wallhavend/StatusBarController.swift
@@ -76,7 +76,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
 		autoUpdateItem.target = self
 
 		// Auto-update can run offline in Pinned-only mode (it never downloads).
-		let canRunAutoUpdate = wallpaperManager.isOnline || wallpaperManager.isRunning || wallpaperManager.effectiveRotationMode == .pinnedOnly
+		let canRunAutoUpdate = wallpaperManager.isOnline || wallpaperManager.isRunning || wallpaperManager.rotationMode == .pinnedOnly
 		autoUpdateItem.isEnabled = canRunAutoUpdate
 		menu.addItem(autoUpdateItem)
 

--- a/Wallhavend/WallpaperManager+Prefetch.swift
+++ b/Wallhavend/WallpaperManager+Prefetch.swift
@@ -60,7 +60,7 @@ extension WallpaperManager {
 	/// so this gates only on the engine being active, the session live, being online, and `.fresh` mode — Pinned-only
 	/// never downloads. The pool-size skip (≤ 1) lives in `bucketsNeedingFill`, which then returns no targets.
 	var shouldPrefetch: Bool {
-		isRunning && isSessionActive && isOnline && effectiveRotationMode == .fresh
+		isRunning && isSessionActive && isOnline && rotationMode == .fresh
 	}
 
 	/// Watch for search/pool settings changes that should refill the pool, debounced so per-keystroke typing coalesces

--- a/Wallhavend/WallpaperManager+Wallpaper.swift
+++ b/Wallhavend/WallpaperManager+Wallpaper.swift
@@ -2,15 +2,29 @@ import Foundation
 import AppKit
 
 extension WallpaperManager {
-	/// The automatic rotation tick. In `.fresh` mode it fetches fresh online and rotates the pool offline; in `.pinnedOnly` it never downloads and cycles only the pinned set (so it works offline too).
+	/// The user-facing explanation for a scheduled update that has nothing to do: Pinned only is selected but nothing is pinned. `nil` whenever rotation has work.
+	static func pinnedRotationPausedMessage(mode: RotationMode, pinnedIds: Set<String>) -> String? {
+		if mode == .pinnedOnly && pinnedIds.isEmpty {
+			return "Nothing is pinned — automatic updates are paused. Pin a wallpaper or switch to Fresh."
+		} else {
+			return nil
+		}
+	}
+
+	/// The automatic rotation tick. In `.fresh` mode it fetches fresh online and rotates the pool offline; in `.pinnedOnly` it never downloads and cycles only the pinned set (so it works offline too). Pinned only with nothing pinned pauses and surfaces why through `error` instead of silently skipping.
 	func updateWallpaper() async {
 		error = nil
+
+		if let pausedMessage = Self.pinnedRotationPausedMessage(mode: rotationMode, pinnedIds: WallhavenService.shared.pinnedIds) {
+			error = pausedMessage
+			return
+		}
 
 		guard let screensByBucket = currentScreensByBucket() else {
 			return
 		}
 
-		switch effectiveRotationMode {
+		switch rotationMode {
 			case .fresh:
 				await runFreshUpdate(screensByBucket: screensByBucket)
 			case .pinnedOnly:
@@ -32,7 +46,7 @@ extension WallpaperManager {
 
 	/// Run the normal update for a single bucket, respecting the current rotation mode (used by the block-replacement fallback).
 	func updateBucket(_ bucket: AspectBucket, screens: [NSScreen]) async {
-		switch effectiveRotationMode {
+		switch rotationMode {
 			case .fresh:
 				if isOnline {
 					await updateWallpaperForBucket(bucket: bucket, screens: screens)

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -11,6 +11,7 @@ enum RotationMode: String, CaseIterable, Identifiable {
 
 	/// Never download — cycle only the pinned set.
 	/// Works offline; the manual "Update Wallpaper Now" still fetches fresh.
+	/// With nothing pinned, scheduled updates pause (and say so in the UI) rather than fall back to downloading.
 	case pinnedOnly = "pinned_only"
 
 	var id: String { rawValue }
@@ -80,15 +81,6 @@ class WallpaperManager: ObservableObject {
 	@Published var rotationMode: RotationMode = .fresh {
 		didSet {
 			UserDefaults.standard.set(rotationMode.rawValue, forKey: "rotationMode")
-		}
-	}
-
-	/// The rotation mode the engine actually uses. Pinned-only with zero pins is a dead state (never downloads, nothing to cycle), so it falls back to `.fresh` — matching what the settings picker shows when no pins exist.
-	var effectiveRotationMode: RotationMode {
-		if rotationMode == .pinnedOnly && WallhavenService.shared.pinnedIds.isEmpty {
-			return .fresh
-		} else {
-			return rotationMode
 		}
 	}
 

--- a/WallhavendTests/RotationModeTests.swift
+++ b/WallhavendTests/RotationModeTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Wallhavend
+
+@MainActor
+final class RotationModeTests: XCTestCase {
+	// MARK: - pinnedRotationPausedMessage: scheduled updates pause instead of downloading when Pinned only has nothing pinned
+
+	func testPausedMessageWhenPinnedOnlyAndNothingPinned() {
+		let result = WallpaperManager.pinnedRotationPausedMessage(mode: .pinnedOnly, pinnedIds: [])
+
+		XCTAssertEqual(result, "Nothing is pinned — automatic updates are paused. Pin a wallpaper or switch to Fresh.")
+	}
+
+	func testNoPausedMessageWhenPinnedOnlyHasPins() {
+		let result = WallpaperManager.pinnedRotationPausedMessage(mode: .pinnedOnly, pinnedIds: ["abc123"])
+
+		XCTAssertNil(result)
+	}
+
+	func testNoPausedMessageInFreshModeEvenWithNothingPinned() {
+		let result = WallpaperManager.pinnedRotationPausedMessage(mode: .fresh, pinnedIds: [])
+
+		XCTAssertNil(result)
+	}
+
+	// MARK: - rotationCaption: the Advanced tab caption tracks the pinned-idle state
+
+	func testCaptionExplainsBothModesWheneverPinsExist() {
+		let expected = "Fresh downloads new wallpapers (and rotates your pool when offline). Pinned only never downloads — it cycles just your pinned wallpapers. “Update Now” always fetches a fresh one."
+
+		XCTAssertEqual(AdvancedTab.rotationCaption(storedMode: .fresh, hasPins: true), expected)
+		XCTAssertEqual(AdvancedTab.rotationCaption(storedMode: .pinnedOnly, hasPins: true), expected)
+	}
+
+	func testCaptionHintsToEnablePinnedOnlyWhenFreshWithNothingPinned() {
+		let result = AdvancedTab.rotationCaption(storedMode: .fresh, hasPins: false)
+
+		XCTAssertEqual(result, "Fresh downloads new wallpapers (and rotates your pool when offline). Pin a wallpaper to enable Pinned only.")
+	}
+
+	func testCaptionWarnsPausedWhenPinnedOnlyWithNothingPinned() {
+		let result = AdvancedTab.rotationCaption(storedMode: .pinnedOnly, hasPins: false)
+
+		XCTAssertEqual(result, "Pinned only never downloads, and nothing is pinned — automatic updates are paused. Pin a wallpaper or switch to Fresh. “Update Now” still fetches a fresh one.")
+	}
+}


### PR DESCRIPTION
Closes #73.

## Premise correction

The issue (mirroring android) describes scheduled rotation as silently *stalling* in Pinned only with nothing pinned. macOS actually did something different: since the pin feature landed (35a024c), `effectiveRotationMode` silently rewrote that state to Fresh, so scheduled updates kept **downloading** — background prefetch included — against the mode's documented "never downloads" contract. (Observable on 2.7.1: with Pinned only stored and zero pins, fresh wallpapers keep arriving on schedule.)

## What changed

- **Engine**: the `effectiveRotationMode` fallback is deleted; the engine dispatches on the stored mode. A scheduled tick in Pinned only with an empty pinned set now genuinely pauses — no downloads, no prefetch — matching android's semantics.
- **Warning, via the existing error channel**: that paused tick reports "Nothing is pinned — automatic updates are paused. Pin a wallpaper or switch to Fresh." through `wallpaperManager.error`, so it appears in the shared footer on every tab, exactly like other update-attempt messages, and clears on the next attempt that has work.
- **Advanced tab**: the Rotation picker no longer coerces its display to Fresh — it shows the stored Pinned only selection honestly (still disabled for *entering* without pins, unchanged guard), and the caption explains the paused state.
- **Unchanged**: "Update Wallpaper Now" remains the manual escape hatch (always fetches fresh; also clears the paused message until the next scheduled tick). Per-bucket partial idle (pins exist but none usable for one aspect bucket) stays console-only, matching android's global-empty-only banner.

Unit tests cover the pause-decision and caption matrices (`RotationModeTests`); verified end-to-end by driving a Debug build: paused tick shows the footer warning with no download, the Advanced tab shows the honest selection and caption, and a manual Update Now still fetches and clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)