### PR TITLE
Widen the settings window and fix its real minimum size

### DIFF
--- a/Wallhavend/AppDelegate.swift
+++ b/Wallhavend/AppDelegate.swift
@@ -48,7 +48,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 		}
 
 		let window = NSWindow(
-			contentRect: NSRect(x: 0, y: 0, width: 400, height: 540),
+			contentRect: NSRect(x: 0, y: 0, width: 500, height: 540),
 			styleMask: [.titled, .closable, .miniaturizable, .resizable],
 			backing: .buffered,
 			defer: false
@@ -59,13 +59,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 			.environmentObject(WallhavenService.shared)
 
 		let hostingView = NSHostingView(rootView: contentView)
-		hostingView.frame = NSRect(x: 0, y: 0, width: 400, height: 540)
+		hostingView.frame = NSRect(x: 0, y: 0, width: 500, height: 540)
 		hostingView.autoresizingMask = [.width, .height]
 
 		window.contentView = hostingView
 		window.title = "Wallhavend Settings"
-		window.contentMinSize = NSSize(width: 400, height: 480)
-		window.setContentSize(NSSize(width: 400, height: 540))
+		window.contentMinSize = NSSize(width: 500, height: 480)
+		window.setContentSize(NSSize(width: 500, height: 540))
 		window.center()
 
 		let windowController = NSWindowController(window: window)

--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -94,6 +94,6 @@ struct ContentView: View {
 			}
 			.padding()
 		}
-		.frame(minWidth: 320, minHeight: 300)
+		.frame(minWidth: 500, minHeight: 480)
 	}
 }


### PR DESCRIPTION
Closes #74.

Two layers to this one:

- **Symptom**: the footer's three buttons ("Start/Stop Auto Update", "Update Wallpaper Now", "Show in Finder") need ~490 pt at current system font metrics, so the 400 pt window truncated their titles. Titles stay explicit — "Update Now" alone would be ambiguous against the app-update vocabulary ("Check for Updates…").
- **Root cause underneath**: `NSWindow.contentMinSize` was never actually the floor. With an `NSHostingView` as the content view, the window's effective minimum comes from the SwiftUI `.frame(minWidth:minHeight:)` — which was 320×300 — so the window could be dragged well below even the old 400 pt and truncate arbitrarily hard.

The window now opens at 500 pt and ContentView's frame minimums are raised to 500×480 (kept in sync with `contentMinSize`).

Verified on the built app: opens at 500×572 with all three titles untruncated; synthetic edge-drag resizing grows the window (proving the handle engages) and an aggressive 400 pt overshrink stops at exactly 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)