### PR TITLE
Add an About menu item with version and repository link

### DIFF
--- a/Wallhavend/StatusBarController.swift
+++ b/Wallhavend/StatusBarController.swift
@@ -82,6 +82,10 @@ class StatusBarController: NSObject, NSMenuDelegate {
 
 		menu.addItem(.separator())
 
+		let aboutItem = NSMenuItem(title: "About Wallhavend", action: #selector(showAbout), keyEquivalent: "")
+		aboutItem.target = self
+		menu.addItem(aboutItem)
+
 		let settingsItem = NSMenuItem(title: "Open Settings...", action: #selector(openSettings), keyEquivalent: ",")
 		settingsItem.target = self
 		menu.addItem(settingsItem)
@@ -117,6 +121,27 @@ class StatusBarController: NSObject, NSMenuDelegate {
 		} else {
 			wallpaperManager.startAutoUpdate()
 		}
+	}
+
+	@objc
+	private func showAbout() {
+		NSApp.activate(ignoringOtherApps: true)
+
+		let repositoryURL = URL(string: "https://github.com/Attacktive/Wallhavend")!
+		let paragraphStyle = NSMutableParagraphStyle()
+		paragraphStyle.alignment = .center
+
+		let credits = NSAttributedString(
+			string: repositoryURL.absoluteString,
+			attributes: [
+				.link: repositoryURL,
+				.font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize),
+				.paragraphStyle: paragraphStyle
+			]
+		)
+
+		// CURRENT_PROJECT_VERSION always equals MARKETING_VERSION here, so the parenthesized build number would just repeat the version.
+		NSApp.orderFrontStandardAboutPanel(options: [.credits: credits, .version: ""])
 	}
 
 	@objc


### PR DESCRIPTION
Adds an "About Wallhavend" item to the status menu, mirroring Roameow's pattern (activate, then `orderFrontStandardAboutPanel`), adapted to this menu's layout: it heads the housekeeping cluster ("About Wallhavend" → "Open Settings..." → "Check for Updates…") rather than displacing "Update Wallpaper Now" from the top.

The panel shows the standard app icon and name, "Version 2.7.1" (the parenthesized build number is suppressed since `CURRENT_PROJECT_VERSION` always equals `MARKETING_VERSION`), and a clickable https://github.com/Attacktive/Wallhavend link in the credits area.

Verified by driving the built app's status menu via accessibility: the item appears in the intended slot, and clicking it opens the panel with the version line and the repository link rendered as a link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)