### PR TITLE
feature: skip auto-update ticks while the screen is locked

### DIFF
--- a/Wallhavend/WallpaperManager+Prefetch.swift
+++ b/Wallhavend/WallpaperManager+Prefetch.swift
@@ -57,10 +57,10 @@ extension WallpaperManager {
 	}
 
 	/// Whether background pre-filling should run right now. Bursts are allowed on any connection (the settled design),
-	/// so this gates only on the engine being active, the session live, being online, and `.fresh` mode — Pinned-only
+	/// so this gates only on the engine being active, the session live, the screen unlocked, being online, and `.fresh` mode — Pinned-only
 	/// never downloads. The pool-size skip (≤ 1) lives in `bucketsNeedingFill`, which then returns no targets.
 	var shouldPrefetch: Bool {
-		isRunning && isSessionActive && isOnline && rotationMode == .fresh
+		isRunning && isSessionActive && !isScreenLocked && isOnline && rotationMode == .fresh
 	}
 
 	/// Watch for search/pool settings changes that should refill the pool, debounced so per-keystroke typing coalesces

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -34,6 +34,10 @@ class WallpaperManager: ObservableObject {
 	private var sessionDidBecomeActiveObserver: NSObjectProtocol?
 	var isSessionActive: Bool = true
 
+	private var screenDidLockObserver: NSObjectProtocol?
+	private var screenDidUnlockObserver: NSObjectProtocol?
+	var isScreenLocked: Bool = false
+
 	private let networkMonitor = NetworkMonitor.shared
 	private var networkCancellable: AnyCancellable?
 
@@ -56,6 +60,7 @@ class WallpaperManager: ObservableObject {
 		_rotationMode = Published(initialValue: storedMode)
 
 		setupSessionObservers()
+		setupScreenLockObservers()
 		setupNetworkObserver()
 		loadPoolFromDisk()
 		setupSettingsObserver()
@@ -198,7 +203,12 @@ class WallpaperManager: ObservableObject {
 		guard isRunning else { return }
 
 		guard isSessionActive else {
-			print("Session inactive (screensaver/lock). Skipping auto-update.")
+			print("Session inactive (fast user switch). Skipping auto-update.")
+			return
+		}
+
+		guard !isScreenLocked else {
+			print("Screen locked. Skipping auto-update.")
 			return
 		}
 
@@ -230,6 +240,38 @@ class WallpaperManager: ObservableObject {
 
 			Task { @MainActor in
 				self.isSessionActive = true
+				self.requestPoolTopUp()
+			}
+		}
+	}
+
+	/// Screen lock/unlock gating.
+	/// `NSWorkspace.sessionDidResignActive` only fires on fast user switching, so locking the screen needs its own signal.
+	/// While locked we skip the visible rotation and pause background fills; on unlock the fill resumes.
+	/// Delivered as `DistributedNotificationCenter` broadcasts.
+	private func setupScreenLockObservers() {
+		screenDidLockObserver = DistributedNotificationCenter.default().addObserver(
+			forName: Notification.Name("com.apple.screenIsLocked"),
+			object: nil,
+			queue: .main
+		) { [weak self] _ in
+			guard let self else { return }
+
+			Task { @MainActor in
+				self.isScreenLocked = true
+				self.cancelPoolTopUp()
+			}
+		}
+
+		screenDidUnlockObserver = DistributedNotificationCenter.default().addObserver(
+			forName: Notification.Name("com.apple.screenIsUnlocked"),
+			object: nil,
+			queue: .main
+		) { [weak self] _ in
+			guard let self else { return }
+
+			Task { @MainActor in
+				self.isScreenLocked = false
 				self.requestPoolTopUp()
 			}
 		}


### PR DESCRIPTION
## What

Auto-update rotation now pauses while the screen is locked and resumes after unlock. The wallpaper no longer rotates for a screen nobody's looking at, and background prefetch stops downloading ahead while you're away.

## How

- Subscribe to the `com.apple.screenIsLocked` / `com.apple.screenIsUnlocked` distributed notifications and track a dedicated `isScreenLocked` flag.
- The rotation tick skips while locked; `shouldPrefetch` gates on it too, cancelling any in-flight fill on lock and restarting on unlock.

## Why a dedicated flag

There was already an `isSessionActive` gate whose comment claimed it covered *"screensaver/lock"* — but it's driven by `NSWorkspace.sessionDidResignActive`, which only fires on **fast user switching**, never on screen lock. The intent was there; the coverage wasn't. Rather than fold lock into that boolean (where fast-user-switch and lock could desync a shared flag), this adds a separate `isScreenLocked` and combines them in the tick guard. The now-accurate session log message is corrected in passing.

## Note on the sandbox

The app is sandboxed, and the sandbox is known to filter some distributed notifications. Confirmed empirically on a sandboxed build that both notifications are delivered, so no lower-level fallback (e.g. a `CGSession` lock check) is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
