### PR TITLE
feature: strip the poisonous wallpaper config while the screen is locked

### DIFF
--- a/Wallhavend.xcodeproj/project.pbxproj
+++ b/Wallhavend.xcodeproj/project.pbxproj
@@ -17,7 +17,9 @@
 		AA0000012F600000000PINT1 /* PinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000PINT1 /* PinTests.swift */; };
 		AA0000012F600000000PRET1 /* PrefetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000PRET1 /* PrefetchTests.swift */; };
 		AA0000012F600000000ROTM1 /* RotationModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000ROTM1 /* RotationModeTests.swift */; };
+		AA0000012F600000000SANT1 /* WallpaperStoreSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000SANT1 /* WallpaperStoreSanitizerTests.swift */; };
 		AA0000012F600000000POOL1 /* WallpaperManager+Pool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000POOL1 /* WallpaperManager+Pool.swift */; };
+		AA0000012F600000000SANI1 /* WallpaperStoreSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000SANI1 /* WallpaperStoreSanitizer.swift */; };
 		AA0000012F600000000WALL1 /* WallpaperManager+Wallpaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */; };
 		AA0000012F600000000PREF1 /* WallpaperManager+Prefetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000PREF1 /* WallpaperManager+Prefetch.swift */; };
 		D01707E62DCC4F3E00158EDD /* WallhavenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01707E32DCC4F3E00158EDD /* WallhavenAPI.swift */; };
@@ -58,7 +60,9 @@
 		AA0000002F600000000PINT1 /* PinTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000PRET1 /* PrefetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefetchTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000ROTM1 /* RotationModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationModeTests.swift; sourceTree = "<group>"; };
+		AA0000002F600000000SANT1 /* WallpaperStoreSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperStoreSanitizerTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000POOL1 /* WallpaperManager+Pool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Pool.swift"; sourceTree = "<group>"; };
+		AA0000002F600000000SANI1 /* WallpaperStoreSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperStoreSanitizer.swift; sourceTree = "<group>"; };
 		AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Wallpaper.swift"; sourceTree = "<group>"; };
 		AA0000002F600000000PREF1 /* WallpaperManager+Prefetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Prefetch.swift"; sourceTree = "<group>"; };
 		D01707E32DCC4F3E00158EDD /* WallhavenAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallhavenAPI.swift; sourceTree = "<group>"; };
@@ -129,6 +133,7 @@
 				D01707E42DCC4F3E00158EDD /* WallpaperError.swift */,
 				D01707E52DCC4F3E00158EDD /* WallpaperManager.swift */,
 				AA0000002F600000000POOL1 /* WallpaperManager+Pool.swift */,
+				AA0000002F600000000SANI1 /* WallpaperStoreSanitizer.swift */,
 				AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */,
 				AA0000002F600000000PREF1 /* WallpaperManager+Prefetch.swift */,
 				AA0000002F600000000ASPC1 /* AspectBucket.swift */,
@@ -164,6 +169,7 @@
 				AA0000002F600000000PINT1 /* PinTests.swift */,
 				AA0000002F600000000PRET1 /* PrefetchTests.swift */,
 				AA0000002F600000000ROTM1 /* RotationModeTests.swift */,
+				AA0000002F600000000SANT1 /* WallpaperStoreSanitizerTests.swift */,
 				D0ED74A92DCB72F90008C397 /* WallhavendTests.swift */,
 			);
 			path = WallhavendTests;
@@ -286,6 +292,7 @@
 				D0ED74982DCB72EE0008C397 /* WallhavendApp.swift in Sources */,
 				D01707E82DCC4F3E00158EDD /* WallpaperManager.swift in Sources */,
 				AA0000012F600000000POOL1 /* WallpaperManager+Pool.swift in Sources */,
+				AA0000012F600000000SANI1 /* WallpaperStoreSanitizer.swift in Sources */,
 				AA0000012F600000000WALL1 /* WallpaperManager+Wallpaper.swift in Sources */,
 				AA0000012F600000000PREF1 /* WallpaperManager+Prefetch.swift in Sources */,
 				AA0000012F600000000ASPC1 /* AspectBucket.swift in Sources */,
@@ -304,6 +311,7 @@
 				AA0000012F600000000PINT1 /* PinTests.swift in Sources */,
 				AA0000012F600000000PRET1 /* PrefetchTests.swift in Sources */,
 				AA0000012F600000000ROTM1 /* RotationModeTests.swift in Sources */,
+				AA0000012F600000000SANT1 /* WallpaperStoreSanitizerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -38,6 +38,9 @@ class WallpaperManager: ObservableObject {
 	private var screenDidUnlockObserver: NSObjectProtocol?
 	var isScreenLocked: Bool = false
 
+	/// Set while the locked-session sanitizer has stripped our wallpaper config from the store, so unlock knows to put the wallpaper back.
+	var didSanitizeWallpaperStoreWhileLocked = false
+
 	private let networkMonitor = NetworkMonitor.shared
 	private var networkCancellable: AnyCancellable?
 
@@ -247,7 +250,7 @@ class WallpaperManager: ObservableObject {
 
 	/// Screen lock/unlock gating.
 	/// `NSWorkspace.sessionDidResignActive` only fires on fast user switching, so locking the screen needs its own signal.
-	/// While locked we skip the visible rotation and pause background fills; on unlock the fill resumes.
+	/// While locked we skip the visible rotation, pause background fills, and strip our wallpaper config from the wallpaper store so the aerial screensaver dodges the macOS 26.5 WindowServer meltdown (see `WallpaperStoreSanitizer`); on unlock the wallpaper and the fill come back.
 	/// Delivered as `DistributedNotificationCenter` broadcasts.
 	private func setupScreenLockObservers() {
 		screenDidLockObserver = DistributedNotificationCenter.default().addObserver(
@@ -260,6 +263,7 @@ class WallpaperManager: ObservableObject {
 			Task { @MainActor in
 				self.isScreenLocked = true
 				self.cancelPoolTopUp()
+				self.sanitizeWallpaperStoreForLockedSession()
 			}
 		}
 
@@ -272,6 +276,7 @@ class WallpaperManager: ObservableObject {
 
 			Task { @MainActor in
 				self.isScreenLocked = false
+				self.restoreWallpaperAfterUnlock()
 				self.requestPoolTopUp()
 			}
 		}

--- a/Wallhavend/WallpaperStoreSanitizer.swift
+++ b/Wallhavend/WallpaperStoreSanitizer.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// Strips the wallpaper-store configs that melt WindowServer while the aerial screensaver plays.
+///
+/// macOS 26.5 has a compositor bug: whenever WallpaperAgent's store holds a Desktop slot with the legacy image provider — the only kind `NSWorkspace.setDesktopImageURL` can write — WindowServer portal-nests its layer tree and pegs a CPU core for as long as the aerial Idle wallpaper renders, dropping it to a slideshow on ProMotion displays.
+/// Built-in providers (`choice.sonoma`, `choice.macintosh`, …) and the photo-shuffle provider don't trigger the meltdown, and those slots belong to the user, so the sanitizer removes exactly the legacy image slots and nothing else.
+enum WallpaperStoreSanitizer {
+	static let legacyImageProvider = "com.apple.wallpaper.choice.image"
+
+	static var defaultStoreURL: URL {
+		FileManager.default.homeDirectoryForCurrentUser
+			.appendingPathComponent("Library/Application Support/com.apple.wallpaper/Store/Index.plist")
+	}
+
+	/// Removes every `Desktop` slot whose choices use the legacy image provider, anywhere in the tree, and reports how many were removed.
+	static func strippingImageDesktopConfigurations(from root: [String: Any]) -> (result: [String: Any], removedSlotCount: Int) {
+		var removedSlotCount = 0
+
+		func sanitizedDictionary(_ dictionary: [String: Any]) -> [String: Any] {
+			var result = [String: Any]()
+			for (key, value) in dictionary {
+				if key == "Desktop", isLegacyImageSlot(value) {
+					removedSlotCount += 1
+					continue
+				}
+
+				result[key] = sanitizedValue(value)
+			}
+
+			return result
+		}
+
+		func sanitizedValue(_ node: Any) -> Any {
+			if let dictionary = node as? [String: Any] {
+				return sanitizedDictionary(dictionary)
+			} else if let array = node as? [Any] {
+				return array.map(sanitizedValue)
+			} else {
+				return node
+			}
+		}
+
+		let result = sanitizedDictionary(root)
+
+		return (result, removedSlotCount)
+	}
+
+	private static func isLegacyImageSlot(_ value: Any) -> Bool {
+		guard
+			let slot = value as? [String: Any],
+			let content = slot["Content"] as? [String: Any],
+			let choices = content["Choices"] as? [[String: Any]]
+		else {
+			return false
+		}
+
+		return choices.contains { $0["Provider"] as? String == legacyImageProvider }
+	}
+
+	/// Reads the store, strips the legacy image Desktop slots, and writes it back atomically. Returns whether the file changed.
+	@discardableResult
+	static func sanitizeStore(at url: URL = defaultStoreURL) throws -> Bool {
+		let data = try Data(contentsOf: url)
+		guard let root = try PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any] else {
+			return false
+		}
+
+		let (result, removedSlotCount) = strippingImageDesktopConfigurations(from: root)
+		guard removedSlotCount > 0 else {
+			return false
+		}
+
+		let output = try PropertyListSerialization.data(fromPropertyList: result, format: .binary, options: 0)
+		try output.write(to: url, options: .atomic)
+
+		return true
+	}
+
+	/// WallpaperAgent only rereads the store on launch, so a strip must be followed by a relaunch; launchd respawns the agent immediately.
+	/// Only call this after the sanitizer actually removed something — a relaunch mid-lock with any surviving Desktop slot retriggers the very meltdown this works around.
+	static func relaunchWallpaperAgent() {
+		let process = Process()
+		process.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
+		process.arguments = ["WallpaperAgent"]
+
+		do {
+			try process.run()
+		} catch {
+			print("Failed to relaunch WallpaperAgent: \(error)")
+		}
+	}
+}
+
+extension WallpaperManager {
+	/// Locked-session guard: nobody sees the desktop while the screen is locked, so dropping the poisonous config costs nothing and buys a smooth aerial.
+	func sanitizeWallpaperStoreForLockedSession() {
+		do {
+			let changed = try WallpaperStoreSanitizer.sanitizeStore()
+			if changed {
+				didSanitizeWallpaperStoreWhileLocked = true
+				WallpaperStoreSanitizer.relaunchWallpaperAgent()
+				print("Stripped legacy image wallpaper configs for the locked session.")
+			}
+		} catch {
+			print("Skipping wallpaper-store sanitizing: \(error)")
+		}
+	}
+
+	/// Undo of the locked-session strip: put the current wallpaper back the moment the user can see the desktop again.
+	func restoreWallpaperAfterUnlock() {
+		guard didSanitizeWallpaperStoreWhileLocked else {
+			return
+		}
+
+		didSanitizeWallpaperStoreWhileLocked = false
+
+		guard let screensByBucket = currentScreensByBucket() else {
+			return
+		}
+
+		for (bucket, screens) in screensByBucket {
+			guard let url = currentByBucket[bucket.rawValue] else {
+				continue
+			}
+
+			do {
+				try applyWallpaper(url: url, to: screens)
+			} catch {
+				print("Failed to restore the wallpaper after unlock: \(error)")
+			}
+		}
+	}
+}

--- a/WallhavendTests/WallpaperStoreSanitizerTests.swift
+++ b/WallhavendTests/WallpaperStoreSanitizerTests.swift
@@ -1,0 +1,254 @@
+import XCTest
+@testable import Wallhavend
+
+/// The sanitizer guards the aerial screensaver against the macOS 26.5 WindowServer meltdown: any Desktop slot using the legacy image provider in WallpaperAgent's store makes the compositor portal-nest its layer tree and peg a core while the aerial Idle wallpaper renders.
+/// These tests pin the ownership rule: strip exactly the legacy image slots (the kind `setDesktopImageURL` writes), never the user's built-in or photo-shuffle choices, and report whether anything changed so the caller can skip the WallpaperAgent relaunch when the store was already safe.
+final class WallpaperStoreSanitizerTests: XCTestCase {
+	private let displayUUID = "37D8832A-2D66-02CA-B9F7-8F30A301B230"
+	private let spaceUUID = "66ABA353-E405-47F7-B1EB-BE97A0551DDD"
+
+	// MARK: - Fixtures mirroring the real store shapes captured on macOS 26.5.2
+
+	private func slot(provider: String) -> [String: Any] {
+		[
+			"Content": [
+				"Choices": [
+					[
+						"Provider": provider,
+						"Configuration": Data([0x62, 0x70]),
+						"Files": [Any]()
+					]
+				],
+				"EncodedOptionValues": Data([0x62, 0x70]),
+				"Shuffle": "$null"
+			],
+			"LastSet": Date(timeIntervalSince1970: 1_752_000_000),
+			"LastUse": Date(timeIntervalSince1970: 1_752_000_100)
+		]
+	}
+
+	private func idleAerialsSlot() -> [String: Any] {
+		slot(provider: "com.apple.wallpaper.choice.aerials")
+	}
+
+	/// The four-scope shape the legacy `setDesktopImageURL` path writes: the same image Desktop slot at SystemDefault, the Space default, the per-Space display override, and the display scope.
+	private func legacyPoisonedStore() -> [String: Any] {
+		[
+			"AllSpacesAndDisplays": [
+				"Idle": idleAerialsSlot(),
+				"Type": "idle"
+			],
+			"SystemDefault": [
+				"Desktop": slot(provider: WallpaperStoreSanitizer.legacyImageProvider),
+				"Idle": idleAerialsSlot(),
+				"Type": "individual"
+			],
+			"Spaces": [
+				spaceUUID: [
+					"Default": [
+						"Desktop": slot(provider: WallpaperStoreSanitizer.legacyImageProvider),
+						"Idle": idleAerialsSlot(),
+						"Type": "individual"
+					],
+					"Displays": [
+						displayUUID: [
+							"Desktop": slot(provider: WallpaperStoreSanitizer.legacyImageProvider),
+							"Type": "individual"
+						]
+					]
+				]
+			],
+			"Displays": [
+				displayUUID: [
+					"Desktop": slot(provider: WallpaperStoreSanitizer.legacyImageProvider),
+					"Idle": idleAerialsSlot(),
+					"Type": "individual"
+				]
+			]
+		]
+	}
+
+	private func builtInStore() -> [String: Any] {
+		[
+			"AllSpacesAndDisplays": [
+				"Desktop": slot(provider: "com.apple.wallpaper.choice.sonoma"),
+				"Idle": idleAerialsSlot(),
+				"Type": "individual"
+			],
+			"SystemDefault": [
+				"Desktop": slot(provider: "com.apple.wallpaper.choice.sonoma"),
+				"Idle": idleAerialsSlot(),
+				"Type": "individual"
+			],
+			"Spaces": [String: Any](),
+			"Displays": [String: Any]()
+		]
+	}
+
+	private func desktopSlotCount(in root: [String: Any], provider: String? = nil) -> Int {
+		var count = 0
+
+		func walk(_ node: Any) {
+			if let dictionary = node as? [String: Any] {
+				for (key, value) in dictionary {
+					if key == "Desktop", let slot = value as? [String: Any], let content = slot["Content"] as? [String: Any] {
+						let choices = content["Choices"] as? [[String: Any]] ?? []
+						if provider == nil || choices.contains(where: { $0["Provider"] as? String == provider }) {
+							count += 1
+						}
+					}
+
+					walk(value)
+				}
+			} else if let array = node as? [Any] {
+				for value in array {
+					walk(value)
+				}
+			}
+		}
+
+		walk(root)
+
+		return count
+	}
+
+	private func idleSlotCount(in root: [String: Any]) -> Int {
+		var count = 0
+
+		func walk(_ node: Any) {
+			if let dictionary = node as? [String: Any] {
+				for (key, value) in dictionary {
+					if key == "Idle", let slot = value as? [String: Any], slot["Content"] != nil {
+						count += 1
+					}
+
+					walk(value)
+				}
+			} else if let array = node as? [Any] {
+				for value in array {
+					walk(value)
+				}
+			}
+		}
+
+		walk(root)
+
+		return count
+	}
+
+	// MARK: - Pure transform
+
+	func testStripsEveryLegacyImageDesktopSlot() {
+		let store = legacyPoisonedStore()
+		XCTAssertEqual(desktopSlotCount(in: store), 4)
+
+		let (result, removedSlotCount) = WallpaperStoreSanitizer.strippingImageDesktopConfigurations(from: store)
+
+		XCTAssertEqual(removedSlotCount, 4)
+		XCTAssertEqual(desktopSlotCount(in: result), 0)
+	}
+
+	func testStrippingPreservesIdleSlotsAndSurroundingKeys() {
+		let store = legacyPoisonedStore()
+
+		let (result, _) = WallpaperStoreSanitizer.strippingImageDesktopConfigurations(from: store)
+
+		XCTAssertEqual(idleSlotCount(in: result), idleSlotCount(in: store))
+		let systemDefault = result["SystemDefault"] as? [String: Any]
+		XCTAssertEqual(systemDefault?["Type"] as? String, "individual")
+		let spaces = result["Spaces"] as? [String: Any]
+		XCTAssertNotNil(spaces?[spaceUUID], "the Space subtree itself must survive; only its Desktop slot goes")
+	}
+
+	func testLeavesBuiltInDesktopSlotsAlone() {
+		let store = builtInStore()
+
+		let (result, removedSlotCount) = WallpaperStoreSanitizer.strippingImageDesktopConfigurations(from: store)
+
+		XCTAssertEqual(removedSlotCount, 0)
+		XCTAssertTrue((result as NSDictionary).isEqual(to: store))
+	}
+
+	func testLeavesPhotoShuffleDesktopSlotsAlone() throws {
+		var store = builtInStore()
+		var allSpaces = try XCTUnwrap(store["AllSpacesAndDisplays"] as? [String: Any])
+		allSpaces["Desktop"] = slot(provider: "com.apple.wallpaper.extension.image")
+		store["AllSpacesAndDisplays"] = allSpaces
+
+		let (result, removedSlotCount) = WallpaperStoreSanitizer.strippingImageDesktopConfigurations(from: store)
+
+		XCTAssertEqual(removedSlotCount, 0)
+		XCTAssertTrue((result as NSDictionary).isEqual(to: store))
+	}
+
+	func testRemovesOnlyImageSlotsInMixedStore() throws {
+		var store = legacyPoisonedStore()
+		var systemDefault = try XCTUnwrap(store["SystemDefault"] as? [String: Any])
+		systemDefault["Desktop"] = slot(provider: "com.apple.wallpaper.choice.sonoma")
+		store["SystemDefault"] = systemDefault
+
+		let (result, removedSlotCount) = WallpaperStoreSanitizer.strippingImageDesktopConfigurations(from: store)
+
+		XCTAssertEqual(removedSlotCount, 3)
+		XCTAssertEqual(desktopSlotCount(in: result), 1)
+		XCTAssertEqual(desktopSlotCount(in: result, provider: "com.apple.wallpaper.choice.sonoma"), 1)
+	}
+
+	func testNoOpOnStoreWithoutDesktopSlots() {
+		let store: [String: Any] = [
+			"AllSpacesAndDisplays": [
+				"Idle": idleAerialsSlot(),
+				"Type": "idle"
+			]
+		]
+
+		let (result, removedSlotCount) = WallpaperStoreSanitizer.strippingImageDesktopConfigurations(from: store)
+
+		XCTAssertEqual(removedSlotCount, 0)
+		XCTAssertTrue((result as NSDictionary).isEqual(to: store))
+	}
+
+	// MARK: - File round trip
+
+	private func temporaryStoreURL() -> URL {
+		FileManager.default.temporaryDirectory
+			.appendingPathComponent("WallpaperStoreSanitizerTests-\(UUID().uuidString)", isDirectory: true)
+			.appendingPathComponent("Index.plist")
+	}
+
+	private func write(_ store: [String: Any], to url: URL) throws {
+		try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+		let data = try PropertyListSerialization.data(fromPropertyList: store, format: .binary, options: 0)
+		try data.write(to: url)
+	}
+
+	func testSanitizeRewritesPoisonedStoreFile() throws {
+		let url = temporaryStoreURL()
+		try write(legacyPoisonedStore(), to: url)
+
+		let changed = try WallpaperStoreSanitizer.sanitizeStore(at: url)
+
+		XCTAssertTrue(changed)
+		let data = try Data(contentsOf: url)
+		let reloaded = try XCTUnwrap(PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any])
+		XCTAssertEqual(desktopSlotCount(in: reloaded), 0)
+		XCTAssertEqual(idleSlotCount(in: reloaded), 4)
+	}
+
+	func testSanitizeLeavesCleanStoreFileUntouched() throws {
+		let url = temporaryStoreURL()
+		try write(builtInStore(), to: url)
+		let before = try Data(contentsOf: url)
+
+		let changed = try WallpaperStoreSanitizer.sanitizeStore(at: url)
+
+		XCTAssertFalse(changed)
+		XCTAssertEqual(try Data(contentsOf: url), before)
+	}
+
+	func testSanitizeThrowsOnMissingStoreFile() {
+		let url = temporaryStoreURL()
+
+		XCTAssertThrowsError(try WallpaperStoreSanitizer.sanitizeStore(at: url))
+	}
+}


### PR DESCRIPTION
## The bug this works around

macOS 26.5 has a WindowServer bug, mapped cell-by-cell on the maintainer's M4 Pro (26.5.2, ProMotion):

| Desktop wallpaper config | Lock-screen aerial |
|---|---|
| none / built-in provider (`sonoma`, …) | smooth |
| `choice.image` — written by `setDesktopImageURL` **or by System Settings' file pick** | WindowServer pegs a core (portal-nested layer-tree prepare), aerial drops to ~0.2 FPS |
| `extension.image` (photo shuffle) | aerial never engages (separate Apple bug, not ours to fight) |
| *any* Desktop slot present when WallpaperAgent cold-reloads during an active lock | same meltdown |

`NSWorkspace.setDesktopImageURL` can only produce `choice.image` slots, so every Wallhavend rotation re-arms the meltdown. No alternative API or provider dodges it — even System Settings' own photo pick triggers it. The 120Hz refresh doubles the per-second prepare cost, which is why 60Hz masks the bug and most 60Hz users never see it.

## What this does

- **On `com.apple.screenIsLocked`:** strip exactly the `choice.image` Desktop slots from `~/Library/Application Support/com.apple.wallpaper/Store/Index.plist` (atomic rewrite) and relaunch WallpaperAgent so it rereads the store. The relaunch happens **only when something was stripped** — a relaunch mid-lock with any surviving Desktop slot is itself a meltdown trigger (last table row).
- **On `com.apple.screenIsUnlocked`:** re-apply the current wallpaper via the normal path. Nobody ever sees the default wallpaper: while locked the desktop is invisible, and the restore lands before the user reaches it.
- **Ownership rule:** built-in and photo-shuffle Desktop slots are the user's choices made in System Settings; the sanitizer never touches them (and stripping a built-in would be pure loss — they're harmless).

The strip+relaunch sequence with no surviving Desktop slot was exercised ~10 times during the investigation and produced an instantly smooth aerial (WindowServer 100% → ~30%) every time.

## Tests

9 new unit tests in `WallpaperStoreSanitizerTests` covering: the four-scope legacy shape is fully stripped; Idle slots and surrounding keys survive; built-in, photo-shuffle, and Desktop-less stores are untouched (byte-identical file no-op); mixed stores lose only the image slots; file round-trip through binary plist; missing store throws. Full suite: 71/71 passing locally (the `WallhavendTests` API tests are live-network and rate-limit if re-run back-to-back).

Manual verification on the affected machine: lock → aerial plays smooth at 120Hz with rotation enabled; unlock → wallpaper restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
