### PR TITLE
fix: apply silently-downloaded automatic updates immediately instead of waiting for quit

### DIFF
--- a/Wallhavend.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Wallhavend.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
-        "version" : "2.9.3"
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
       }
     }
   ],

--- a/Wallhavend/AppDelegate.swift
+++ b/Wallhavend/AppDelegate.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import Sparkle
 
 @MainActor
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 	var statusBarController: StatusBarController?
 
 	private var settingsWindowController: NSWindowController?
@@ -17,7 +17,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 		if !isRunningTests {
 			updaterController = SPUStandardUpdaterController(
 				startingUpdater: true,
-				updaterDelegate: nil,
+				updaterDelegate: self,
 				userDriverDelegate: nil
 			)
 		}
@@ -78,6 +78,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
 	func checkForUpdates() {
 		updaterController?.checkForUpdates(nil)
+	}
+
+	// MARK: - SPUUpdaterDelegate
+
+	/// Installs a silently-downloaded automatic update immediately instead of letting Sparkle defer it to app quit.
+	///
+	/// Wallhavend is a menu-bar agent that users basically never quit, so Sparkle's default "install on quit" leaves a background-downloaded update staged forever: when no delegate handles this callback, the automatic driver aborts and waits for a termination that never comes (see SPUAutomaticUpdateDriver).
+	/// Invoking the block and returning true tells Sparkle to install and relaunch right away, which is what makes automatic updates actually land on a background app.
+	func updater(
+		_ updater: SPUUpdater,
+		willInstallUpdateOnQuit item: SUAppcastItem,
+		immediateInstallationBlock immediateInstallHandler: @escaping () -> Void
+	) -> Bool {
+		immediateInstallHandler()
+		return true
 	}
 }
 


### PR DESCRIPTION
Ports the Roameow auto-update fix (Attacktive/Roameow#22) to Wallhavend — same root cause, same setup.

## The bug

Automatic (scheduled) updates never applied; manual **Check for Updates…** always worked.

With `SUAutomaticallyUpdate=YES`, Sparkle downloads updates in the background and — for a *running* app — **defers installation to app quit**. `SPUAutomaticUpdateDriver` only installs immediately if the `SPUUpdaterDelegate` implements `updater:willInstallUpdateOnQuit:immediateInstallationBlock:`; with **no delegate**, it aborts and leaves the update staged for a termination that never comes.

Wallhavend built its updater with **`updaterDelegate: nil`** (`AppDelegate.swift:20`) and is a menu-bar `LSUIElement` agent users never quit → staged updates never landed. Verified identical config to Roameow: `LSUIElement`, `SUEnableAutomaticChecks`, `SUAutomaticallyUpdate` all true; same feed/EdDSA key.

## The fix

Make `AppDelegate` the `SPUUpdaterDelegate`, pass `updaterDelegate: self`, and invoke the immediate-install block so a found update installs + relaunches on the spot. (Under Swift 5 the `@MainActor` class satisfies the `@objc` witness with no `nonisolated` needed.)

## Also in this PR

- `chore: bump Sparkle to 2.9.4` — aligns with Roameow; pin already allowed it (`upToNextMajorVersion` from 2.9.0), so only `Package.resolved` changed.

## Rollout caveat (same as Roameow)

The delegate runs in the *currently-installed* app, so this only takes effect once a build **containing the fix** is installed — existing installs need **one** last manual update to reach it; automatic updates work from there on.

## Verification

- `xcodebuild test` — **TEST SUCCEEDED**; delegate conformance + callback compile and link against Sparkle 2.9.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)