### PR TITLE
fix: apply interval changes immediately and honor explicit Stop across relaunches

### DIFF
--- a/Wallhavend/AppDelegate.swift
+++ b/Wallhavend/AppDelegate.swift
@@ -33,7 +33,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 			}
 		}
 
-		if startAutoUpdateOnLaunch {
+		// Auto-start additionally honors the user's last explicit Start/Stop: a Stop must survive relaunches, including the ones Sparkle performs on its own after a silent update.
+		if startAutoUpdateOnLaunch && wallpaperManager.autoUpdateUserIntent {
 			wallpaperManager.startAutoUpdate()
 		}
 	}

--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -65,9 +65,9 @@ struct ContentView: View {
 				HStack(spacing: 20) {
 					Button(wallpaperManager.isRunning ? "Stop Auto Update" : "Start Auto Update") {
 						if wallpaperManager.isRunning {
-							wallpaperManager.stopAutoUpdate()
+							wallpaperManager.stopAutoUpdateExplicitly()
 						} else {
-							wallpaperManager.startAutoUpdate(interval: updateInterval)
+							wallpaperManager.startAutoUpdateExplicitly(interval: updateInterval)
 						}
 					}
 					.buttonStyle(.borderedProminent)

--- a/Wallhavend/StatusBarController.swift
+++ b/Wallhavend/StatusBarController.swift
@@ -117,9 +117,9 @@ class StatusBarController: NSObject, NSMenuDelegate {
 	@objc
 	private func toggleAutoUpdate() {
 		if wallpaperManager.isRunning {
-			wallpaperManager.stopAutoUpdate()
+			wallpaperManager.stopAutoUpdateExplicitly()
 		} else {
-			wallpaperManager.startAutoUpdate()
+			wallpaperManager.startAutoUpdateExplicitly()
 		}
 	}
 

--- a/Wallhavend/WallpaperManager+Prefetch.swift
+++ b/Wallhavend/WallpaperManager+Prefetch.swift
@@ -63,9 +63,9 @@ extension WallpaperManager {
 		isRunning && isSessionActive && !isScreenLocked && isOnline && rotationMode == .fresh
 	}
 
-	/// Watch for search/pool settings changes that should refill the pool, debounced so per-keystroke typing coalesces
-	/// into a single restart. `UserDefaults.didChangeNotification` is the one signal that catches both the manager's
-	/// `@Published` settings and the service's `@AppStorage` ones; the snapshot compare filters out unrelated writes.
+	/// Watch for settings changes that should reshape running work, debounced so per-keystroke typing coalesces into a single restart.
+	/// `UserDefaults.didChangeNotification` is the one signal that catches both the manager's `@Published` settings and the service's `@AppStorage` ones; the snapshot compare filters out unrelated writes.
+	/// Besides refilling the pool, this is also what lets a new update interval take effect immediately instead of waiting out the current sleep.
 	func setupSettingsObserver() {
 		lastPrefetchInputs = currentPrefetchInputs()
 
@@ -74,6 +74,8 @@ extension WallpaperManager {
 			.debounce(for: .milliseconds(500), scheduler: RunLoop.main)
 			.sink { [weak self] _ in
 				guard let self else { return }
+
+				self.restartAutoUpdateIfIntervalChanged()
 
 				let snapshot = self.currentPrefetchInputs()
 				guard snapshot != self.lastPrefetchInputs else { return }

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -132,7 +132,7 @@ class WallpaperManager: ObservableObject {
 		return dateFormatter.string(from: lastUpdated)
 	}
 
-	func startAutoUpdate(interval: TimeInterval? = nil) {
+	func startAutoUpdate(interval: TimeInterval? = nil, tickImmediately: Bool = true) {
 		timerInterval = interval ?? savedUpdateInterval
 
 		stopAutoUpdate()
@@ -144,7 +144,7 @@ class WallpaperManager: ObservableObject {
 		autoUpdateTask = Task { [weak self] in
 			guard let self else { return }
 
-			await self.runAutoUpdateLoop()
+			await self.runAutoUpdateLoop(tickImmediately: tickImmediately)
 		}
 	}
 
@@ -153,6 +153,45 @@ class WallpaperManager: ObservableObject {
 		autoUpdateTask = nil
 		isRunning = false
 		cancelPoolTopUp()
+	}
+
+	/// The user's last explicit Start/Stop choice, persisted so it survives relaunch.
+	/// Defaults to true, so "Start automatically on launch" works until the user explicitly stops.
+	/// `bool(forKey:)` rather than a `Bool` cast, so coercible values (e.g. `-autoUpdateUserIntent NO` launch arguments, which arrive as strings) are honored too.
+	var autoUpdateUserIntent: Bool {
+		let defaults = UserDefaults.standard
+
+		return if defaults.object(forKey: "autoUpdateUserIntent") == nil {
+			true
+		} else {
+			defaults.bool(forKey: "autoUpdateUserIntent")
+		}
+	}
+
+	/// User-facing Start: records the explicit intent, then starts.
+	func startAutoUpdateExplicitly(interval: TimeInterval? = nil) {
+		UserDefaults.standard.set(true, forKey: "autoUpdateUserIntent")
+		startAutoUpdate(interval: interval)
+	}
+
+	/// User-facing Stop: records the explicit intent, then stops.
+	/// Without the record, "start on launch" would resurrect auto-update on the next relaunch — and Sparkle's silent updates relaunch the app without the user asking.
+	func stopAutoUpdateExplicitly() {
+		UserDefaults.standard.set(false, forKey: "autoUpdateUserIntent")
+		stopAutoUpdate()
+	}
+
+	/// Restarts the tick loop when the user picks a new interval while it runs, so the change doesn't wait out the current (possibly hours-long) sleep.
+	/// Only the delay changes — restarting must not rotate the wallpaper on the spot, hence `tickImmediately: false`.
+	/// The restart cancels any in-flight pool fill along the way, so it re-requests one rather than leaving the pool short until the next tick.
+	func restartAutoUpdateIfIntervalChanged() {
+		guard isRunning else { return }
+
+		let interval = savedUpdateInterval
+		guard interval != timerInterval else { return }
+
+		startAutoUpdate(interval: interval, tickImmediately: false)
+		requestPoolTopUp()
 	}
 
 	private func setupNetworkObserver() {
@@ -176,8 +215,10 @@ class WallpaperManager: ObservableObject {
 			}
 	}
 
-	private func runAutoUpdateLoop() async {
-		await self.performAutoUpdateTick()
+	private func runAutoUpdateLoop(tickImmediately: Bool) async {
+		if tickImmediately {
+			await self.performAutoUpdateTick()
+		}
 
 		while !Task.isCancelled {
 			do {


### PR DESCRIPTION
## What

Two auto-update correctness fixes, ported conceptually from the Android sibling:

- **Update-interval changes take effect immediately.** Changing the interval while auto-update runs used to do nothing until the next manual Stop/Start — the loop kept sleeping on the interval captured when Start was pressed. The debounced settings observer now restarts the loop with the new interval. Only the delay changes: the restart deliberately skips the immediate tick, so picking a new interval never rotates the wallpaper on the spot.

- **An explicit Stop now survives relaunch.** "Start automatically on launch" used to restart rotation unconditionally, resurrecting auto-update the user had just stopped — notably on the relaunches Sparkle performs by itself after a silent update. The last explicit Start/Stop is now persisted (`autoUpdateUserIntent`, default true so the launch toggle keeps working out of the box) and the launch gate requires both.

## How

- `WallpaperManager.startAutoUpdate`/`runAutoUpdateLoop` gain a `tickImmediately` parameter (default preserves today's behavior); `restartAutoUpdateIfIntervalChange and re-requests the pool top-up the restartcancels.
- The intent is written only by the user-faciExplicitly`/`stopAutoUpdateExplicitly`, used by the menu bar toggle and the settings footer button) — never by the internal `stopAutoUpdate()`, which `startAutoUpdate()` calls on its own.
- The intent read uses `bool(forKey:)` behind a nil check rather than a `Bool` cast, so coercible values (e.g. `-autoUpdateUserIntent NO` launch arguments, re honored too.