### PR TITLE
refactor: derive wallpaper page and thumbnail URLs from a parsed source identity

### DIFF
--- a/Wallhavend.xcodeproj/project.pbxproj
+++ b/Wallhavend.xcodeproj/project.pbxproj
@@ -18,9 +18,11 @@
 		AA0000012F600000000PRET1 /* PrefetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000PRET1 /* PrefetchTests.swift */; };
 		AA0000012F600000000ROTM1 /* RotationModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000ROTM1 /* RotationModeTests.swift */; };
 		AA0000012F600000000SRCH1 /* SearchQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000SRCH1 /* SearchQueryTests.swift */; };
+		AA0000012F600000000WSRC2 /* WallpaperIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000WSRC2 /* WallpaperIdentityTests.swift */; };
 		AA0000012F600000000POOL1 /* WallpaperManager+Pool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000POOL1 /* WallpaperManager+Pool.swift */; };
 		AA0000012F600000000WALL1 /* WallpaperManager+Wallpaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */; };
 		AA0000012F600000000PREF1 /* WallpaperManager+Prefetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000PREF1 /* WallpaperManager+Prefetch.swift */; };
+		AA0000012F600000000WSRC1 /* WallpaperSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000WSRC1 /* WallpaperSource.swift */; };
 		D01707E62DCC4F3E00158EDD /* WallhavenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01707E32DCC4F3E00158EDD /* WallhavenAPI.swift */; };
 		D01707E72DCC4F3E00158EDD /* WallpaperError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01707E42DCC4F3E00158EDD /* WallpaperError.swift */; };
 		D01707E82DCC4F3E00158EDD /* WallpaperManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01707E52DCC4F3E00158EDD /* WallpaperManager.swift */; };
@@ -60,9 +62,11 @@
 		AA0000002F600000000PRET1 /* PrefetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefetchTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000ROTM1 /* RotationModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationModeTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000SRCH1 /* SearchQueryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchQueryTests.swift; sourceTree = "<group>"; };
+		AA0000002F600000000WSRC2 /* WallpaperIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperIdentityTests.swift; sourceTree = "<group>"; };
 		AA0000002F600000000POOL1 /* WallpaperManager+Pool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Pool.swift"; sourceTree = "<group>"; };
 		AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Wallpaper.swift"; sourceTree = "<group>"; };
 		AA0000002F600000000PREF1 /* WallpaperManager+Prefetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Prefetch.swift"; sourceTree = "<group>"; };
+		AA0000002F600000000WSRC1 /* WallpaperSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperSource.swift; sourceTree = "<group>"; };
 		D01707E32DCC4F3E00158EDD /* WallhavenAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallhavenAPI.swift; sourceTree = "<group>"; };
 		D01707E42DCC4F3E00158EDD /* WallpaperError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallpaperError.swift; sourceTree = "<group>"; };
 		D01707E52DCC4F3E00158EDD /* WallpaperManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallpaperManager.swift; sourceTree = "<group>"; };
@@ -134,6 +138,7 @@
 				AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */,
 				AA0000002F600000000PREF1 /* WallpaperManager+Prefetch.swift */,
 				AA0000002F600000000ASPC1 /* AspectBucket.swift */,
+				AA0000002F600000000WSRC1 /* WallpaperSource.swift */,
 				D0ED74972DCB72EE0008C397 /* WallhavendApp.swift */,
 				D0ED74992DCB72EE0008C397 /* ContentView.swift */,
 				AA0000002F600000000CTAB1 /* ContentTab.swift */,
@@ -167,6 +172,7 @@
 				AA0000002F600000000PRET1 /* PrefetchTests.swift */,
 				AA0000002F600000000ROTM1 /* RotationModeTests.swift */,
 				AA0000002F600000000SRCH1 /* SearchQueryTests.swift */,
+				AA0000002F600000000WSRC2 /* WallpaperIdentityTests.swift */,
 				D0ED74A92DCB72F90008C397 /* WallhavendTests.swift */,
 			);
 			path = WallhavendTests;
@@ -292,6 +298,7 @@
 				AA0000012F600000000WALL1 /* WallpaperManager+Wallpaper.swift in Sources */,
 				AA0000012F600000000PREF1 /* WallpaperManager+Prefetch.swift in Sources */,
 				AA0000012F600000000ASPC1 /* AspectBucket.swift in Sources */,
+				AA0000012F600000000WSRC1 /* WallpaperSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -308,6 +315,7 @@
 				AA0000012F600000000PRET1 /* PrefetchTests.swift in Sources */,
 				AA0000012F600000000ROTM1 /* RotationModeTests.swift in Sources */,
 				AA0000012F600000000SRCH1 /* SearchQueryTests.swift in Sources */,
+				AA0000012F600000000WSRC2 /* WallpaperIdentityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Wallhavend/BlockedTab.swift
+++ b/Wallhavend/BlockedTab.swift
@@ -40,17 +40,9 @@ private struct BlockedRow: View {
 
 	@State private var revealed = false
 
-	// Reconstruct the Wallhaven thumbnail URL: th.wallhaven.cc/lg/<first two of id>/<id>.jpg
-	private var thumbnailURL: URL? {
-		guard id.count >= 2 else {
-			return nil
-		}
-
-		return URL(string: "https://th.wallhaven.cc/lg/\(id.prefix(2))/\(id).jpg")
-	}
-
-	private var wallpaperURL: URL? {
-		URL(string: "https://wallhaven.cc/w/\(id)")
+	/// The blocked id is a bare filename stem, so the source and its URLs come from parsing it rather than from any stored field.
+	private var identity: WallpaperIdentity {
+		WallpaperIdentity.parse(stem: id)
 	}
 
 	var body: some View {
@@ -63,8 +55,8 @@ private struct BlockedRow: View {
 					revealed = true
 				}
 
-			if let wallpaperURL {
-				Link(id, destination: wallpaperURL)
+			if let pageURL = identity.pageURL {
+				Link(id, destination: pageURL)
 					.font(.system(.body, design: .monospaced))
 			} else {
 				Text(id)
@@ -83,7 +75,7 @@ private struct BlockedRow: View {
 	@ViewBuilder
 	private var thumbnail: some View {
 		// Tap-to-reveal: blocking is often driven by revulsion, so never re-expose the image until the user explicitly asks for it.
-		if revealed, let thumbnailURL {
+		if revealed, let thumbnailURL = identity.thumbnailURL {
 			AsyncImage(url: thumbnailURL) { image in
 				image
 					.resizable()

--- a/Wallhavend/GalleryTab.swift
+++ b/Wallhavend/GalleryTab.swift
@@ -106,6 +106,12 @@ private struct WallpaperThumbnailView: View {
 		wallhavenService.pinnedIds.contains(wallpaperManager.wallpaperId(for: url))
 	}
 
+	private var copyURLTitle: String {
+		let identity = WallpaperIdentity.parse(stem: wallpaperManager.wallpaperId(for: url))
+
+		return "Copy \(identity.source.displayName) URL"
+	}
+
 	var body: some View {
 		Group {
 			if let nsImage {
@@ -147,8 +153,8 @@ private struct WallpaperThumbnailView: View {
 				wallpaperManager.revealInFinder(url: url)
 			}
 
-			Button("Copy Wallhaven URL") {
-				wallpaperManager.copyWallhavenURL(for: url)
+			Button(copyURLTitle) {
+				wallpaperManager.copyPageURL(for: url)
 			}
 
 			Divider()

--- a/Wallhavend/WallpaperManager+Pool.swift
+++ b/Wallhavend/WallpaperManager+Pool.swift
@@ -209,11 +209,17 @@ extension WallpaperManager {
 		}
 	}
 
-	func copyWallhavenURL(for url: URL) {
-		let id = wallpaperId(for: url)
+	/// Copy the wallpaper's page on whichever site it came from.
+	/// A nil page URL leaves the pasteboard alone — better to no-op than to clear whatever the user had.
+	func copyPageURL(for url: URL) {
+		let identity = WallpaperIdentity.parse(stem: wallpaperId(for: url))
+		guard let pageURL = identity.pageURL else {
+			return
+		}
+
 		let pasteboard = NSPasteboard.general
 		pasteboard.clearContents()
-		pasteboard.setString("https://wallhaven.cc/w/\(id)", forType: .string)
+		pasteboard.setString(pageURL.absoluteString, forType: .string)
 	}
 
 	/// Flip a wallpaper's pinned state. Pinning protects it from pool eviction and adds it to the Pinned-only rotation set.

--- a/Wallhavend/WallpaperSource.swift
+++ b/Wallhavend/WallpaperSource.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Where a saved wallpaper came from.
+/// Raw values are the persisted keys — they appear in filename stems, and in stored settings once a second source becomes selectable — so changing one would orphan every file and preference already written under it.
+enum WallpaperSource: String, CaseIterable {
+	case wallhaven
+	case openverse
+
+	var displayName: String {
+		switch self {
+			case .wallhaven:
+				return "Wallhaven"
+			case .openverse:
+				return "Openverse"
+		}
+	}
+}
+
+/// A wallpaper's source plus its id on that source, recovered from the local filename stem.
+///
+/// Wallhaven stems stay bare forever; only Openverse files carry a qualifying prefix.
+/// That keeps pin, block, and pool membership as exact string equality on the stem — no dual-form matching, no migration of files or stored ids.
+///
+/// The scheme is unambiguous in both directions: Wallhaven ids are short alphanumerics, so no existing stem can start with `openverse_`, and Openverse ids are UUIDs, which contain no commas, so the comma-joined settings sets stay parseable.
+struct WallpaperIdentity: Equatable {
+	let source: WallpaperSource
+	let id: String
+
+	/// Recover the identity from a filename stem (see `WallpaperManager.wallpaperId(for:)`).
+	/// A known `<key>_` prefix with a non-empty tail names the source; anything else is Wallhaven with the whole stem as the id.
+	/// That fallback is deliberate rather than lenient — every file saved before this type existed is bare, so a stem that merely looks prefixed must keep its stem intact instead of being reinterpreted.
+	nonisolated static func parse(stem: String) -> WallpaperIdentity {
+		for source in WallpaperSource.allCases where source != .wallhaven {
+			let prefix = "\(source.rawValue)_"
+			guard stem.hasPrefix(prefix) else { continue }
+
+			let id = String(stem.dropFirst(prefix.count))
+			guard !id.isEmpty else { continue }
+
+			return WallpaperIdentity(source: source, id: id)
+		}
+
+		return WallpaperIdentity(source: .wallhaven, id: stem)
+	}
+
+	/// The filename stem this identity is saved under — the inverse of `parse(stem:)`.
+	var qualifiedStem: String {
+		switch source {
+			case .wallhaven:
+				return id
+			case .openverse:
+				return "\(source.rawValue)_\(id)"
+		}
+	}
+
+	/// The wallpaper's page on its source site.
+	var pageURL: URL? {
+		switch source {
+			case .wallhaven:
+				return URL(string: "https://wallhaven.cc/w/\(id)")
+			case .openverse:
+				return URL(string: "https://openverse.org/image/\(id)")
+		}
+	}
+
+	/// A remotely hosted thumbnail, for the places that have an id but no local file (the Blocked tab).
+	var thumbnailURL: URL? {
+		switch source {
+			case .wallhaven:
+				// th.wallhaven.cc shards by the first two characters of the id, so a shorter id has no thumbnail path at all.
+				guard id.count >= 2 else {
+					return nil
+				}
+
+				return URL(string: "https://th.wallhaven.cc/lg/\(id.prefix(2))/\(id).jpg")
+			case .openverse:
+				return URL(string: "https://api.openverse.org/v1/images/\(id)/thumb/")
+		}
+	}
+}

--- a/WallhavendTests/WallpaperIdentityTests.swift
+++ b/WallhavendTests/WallpaperIdentityTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import Wallhavend
+
+final class WallpaperIdentityTests: XCTestCase {
+	// MARK: - parse
+
+	func testBareStemIsWallhaven() {
+		let identity = WallpaperIdentity.parse(stem: "abc123")
+
+		XCTAssertEqual(identity.source, .wallhaven)
+		XCTAssertEqual(identity.id, "abc123")
+	}
+
+	func testOpenversePrefixIsStripped() {
+		let identity = WallpaperIdentity.parse(stem: "openverse_3f2b1a9c-0000-4000-8000-abcdefabcdef")
+
+		XCTAssertEqual(identity.source, .openverse)
+		XCTAssertEqual(identity.id, "3f2b1a9c-0000-4000-8000-abcdefabcdef")
+	}
+
+	/// A prefix with nothing after it is not an identity — keep the stem whole rather than inventing an empty id.
+	func testOpenversePrefixWithEmptyTailFallsBackToWallhaven() {
+		let identity = WallpaperIdentity.parse(stem: "openverse_")
+
+		XCTAssertEqual(identity.source, .wallhaven)
+		XCTAssertEqual(identity.id, "openverse_")
+	}
+
+	/// Wallhaven files are bare forever, so a literal `wallhaven_` prefix is part of the id, not a qualifier.
+	func testWallhavenPrefixIsNotTreatedAsAQualifier() {
+		let identity = WallpaperIdentity.parse(stem: "wallhaven_x")
+
+		XCTAssertEqual(identity.source, .wallhaven)
+		XCTAssertEqual(identity.id, "wallhaven_x")
+	}
+
+	func testUnknownPrefixFallsBackToWallhaven() {
+		let identity = WallpaperIdentity.parse(stem: "unsplash_abc")
+
+		XCTAssertEqual(identity.source, .wallhaven)
+		XCTAssertEqual(identity.id, "unsplash_abc")
+	}
+
+	// MARK: - qualifiedStem round-trips
+
+	func testWallhavenStemStaysBare() {
+		let identity = WallpaperIdentity(source: .wallhaven, id: "abc123")
+
+		XCTAssertEqual(identity.qualifiedStem, "abc123")
+		XCTAssertEqual(WallpaperIdentity.parse(stem: identity.qualifiedStem), identity)
+	}
+
+	func testOpenverseStemIsQualified() {
+		let identity = WallpaperIdentity(source: .openverse, id: "3f2b1a9c")
+
+		XCTAssertEqual(identity.qualifiedStem, "openverse_3f2b1a9c")
+		XCTAssertEqual(WallpaperIdentity.parse(stem: identity.qualifiedStem), identity)
+	}
+
+	// MARK: - URLs
+
+	func testWallhavenURLs() {
+		let identity = WallpaperIdentity(source: .wallhaven, id: "abc123")
+
+		XCTAssertEqual(identity.pageURL?.absoluteString, "https://wallhaven.cc/w/abc123")
+		XCTAssertEqual(identity.thumbnailURL?.absoluteString, "https://th.wallhaven.cc/lg/ab/abc123.jpg")
+	}
+
+	func testOpenverseURLs() {
+		let identity = WallpaperIdentity(source: .openverse, id: "3f2b1a9c")
+
+		XCTAssertEqual(identity.pageURL?.absoluteString, "https://openverse.org/image/3f2b1a9c")
+		XCTAssertEqual(identity.thumbnailURL?.absoluteString, "https://api.openverse.org/v1/images/3f2b1a9c/thumb/")
+	}
+
+	/// The thumbnail path is sharded by the id's first two characters, so a one-character id has no thumbnail — but it still has a page.
+	func testShortWallhavenIdHasNoThumbnailButStillHasAPage() {
+		let identity = WallpaperIdentity(source: .wallhaven, id: "a")
+
+		XCTAssertNil(identity.thumbnailURL)
+		XCTAssertEqual(identity.pageURL?.absoluteString, "https://wallhaven.cc/w/a")
+	}
+
+	// MARK: - Source keys
+
+	/// Raw values are persisted in filename stems, so they are part of the on-disk format.
+	func testRawValuesAreThePersistedKeys() {
+		XCTAssertEqual(WallpaperSource.wallhaven.rawValue, "wallhaven")
+		XCTAssertEqual(WallpaperSource.openverse.rawValue, "openverse")
+	}
+
+	func testDisplayNamesAreHumanReadable() {
+		XCTAssertEqual(WallpaperSource.wallhaven.displayName, "Wallhaven")
+		XCTAssertEqual(WallpaperSource.openverse.displayName, "Openverse")
+	}
+}


### PR DESCRIPTION
Three places assumed every wallpaper came from Wallhaven and baked it in as string literals: the Blocked tab rebuilt th.wallhaven.cc and wallhaven.cc URLs by hand, the Gallery context menu hardcoded "Copy Wallhaven URL", and copyWallhavenURL pasted a hardcoded page URL.

A new WallpaperIdentity recovers the source and id from a filename stem and owns those URLs, so the UI layer asks rather than assumes. Wallhaven stems stay bare and only a qualified prefix names another source, which keeps pin, block, and pool membership as exact string equality on the stem — no dual-form matching and nothing to migrate on disk or in stored ids.

Behavior is unchanged: every existing file has a bare stem, so it parses as Wallhaven and produces the same URLs and the same menu title as before.