### PR TITLE
feat: add the Openverse engine behind a Wallhaven-only default

### DIFF
--- a/Wallhavend.xcodeproj/project.pbxproj
+++ b/Wallhavend.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		AA0000012F600000000WALL1 /* WallpaperManager+Wallpaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */; };
 		AA0000012F600000000PREF1 /* WallpaperManager+Prefetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000PREF1 /* WallpaperManager+Prefetch.swift */; };
 		AA0000012F600000000WSRC1 /* WallpaperSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000WSRC1 /* WallpaperSource.swift */; };
+		AA0000012F600000000OVSR2 /* SourceRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000OVSR2 /* SourceRoutingTests.swift */; };
+		AA0000012F600000000OVAP2 /* OpenverseMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000OVAP2 /* OpenverseMappingTests.swift */; };
+		AA0000012F600000000OVSR1 /* WallpaperManager+Sources.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000OVSR1 /* WallpaperManager+Sources.swift */; };
+		AA0000012F600000000OVAP1 /* OpenverseAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F600000000OVAP1 /* OpenverseAPI.swift */; };
 		D01707E62DCC4F3E00158EDD /* WallhavenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01707E32DCC4F3E00158EDD /* WallhavenAPI.swift */; };
 		D01707E72DCC4F3E00158EDD /* WallpaperError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01707E42DCC4F3E00158EDD /* WallpaperError.swift */; };
 		D01707E82DCC4F3E00158EDD /* WallpaperManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01707E52DCC4F3E00158EDD /* WallpaperManager.swift */; };
@@ -67,6 +71,10 @@
 		AA0000002F600000000WALL1 /* WallpaperManager+Wallpaper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Wallpaper.swift"; sourceTree = "<group>"; };
 		AA0000002F600000000PREF1 /* WallpaperManager+Prefetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Prefetch.swift"; sourceTree = "<group>"; };
 		AA0000002F600000000WSRC1 /* WallpaperSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperSource.swift; sourceTree = "<group>"; };
+		AA0000002F600000000OVSR2 /* SourceRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceRoutingTests.swift; sourceTree = "<group>"; };
+		AA0000002F600000000OVAP2 /* OpenverseMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenverseMappingTests.swift; sourceTree = "<group>"; };
+		AA0000002F600000000OVSR1 /* WallpaperManager+Sources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WallpaperManager+Sources.swift"; sourceTree = "<group>"; };
+		AA0000002F600000000OVAP1 /* OpenverseAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenverseAPI.swift; sourceTree = "<group>"; };
 		D01707E32DCC4F3E00158EDD /* WallhavenAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallhavenAPI.swift; sourceTree = "<group>"; };
 		D01707E42DCC4F3E00158EDD /* WallpaperError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallpaperError.swift; sourceTree = "<group>"; };
 		D01707E52DCC4F3E00158EDD /* WallpaperManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallpaperManager.swift; sourceTree = "<group>"; };
@@ -139,6 +147,8 @@
 				AA0000002F600000000PREF1 /* WallpaperManager+Prefetch.swift */,
 				AA0000002F600000000ASPC1 /* AspectBucket.swift */,
 				AA0000002F600000000WSRC1 /* WallpaperSource.swift */,
+				AA0000002F600000000OVSR1 /* WallpaperManager+Sources.swift */,
+				AA0000002F600000000OVAP1 /* OpenverseAPI.swift */,
 				D0ED74972DCB72EE0008C397 /* WallhavendApp.swift */,
 				D0ED74992DCB72EE0008C397 /* ContentView.swift */,
 				AA0000002F600000000CTAB1 /* ContentTab.swift */,
@@ -173,6 +183,8 @@
 				AA0000002F600000000ROTM1 /* RotationModeTests.swift */,
 				AA0000002F600000000SRCH1 /* SearchQueryTests.swift */,
 				AA0000002F600000000WSRC2 /* WallpaperIdentityTests.swift */,
+				AA0000002F600000000OVSR2 /* SourceRoutingTests.swift */,
+				AA0000002F600000000OVAP2 /* OpenverseMappingTests.swift */,
 				D0ED74A92DCB72F90008C397 /* WallhavendTests.swift */,
 			);
 			path = WallhavendTests;
@@ -299,6 +311,8 @@
 				AA0000012F600000000PREF1 /* WallpaperManager+Prefetch.swift in Sources */,
 				AA0000012F600000000ASPC1 /* AspectBucket.swift in Sources */,
 				AA0000012F600000000WSRC1 /* WallpaperSource.swift in Sources */,
+				AA0000012F600000000OVSR1 /* WallpaperManager+Sources.swift in Sources */,
+				AA0000012F600000000OVAP1 /* OpenverseAPI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -316,6 +330,8 @@
 				AA0000012F600000000ROTM1 /* RotationModeTests.swift in Sources */,
 				AA0000012F600000000SRCH1 /* SearchQueryTests.swift in Sources */,
 				AA0000012F600000000WSRC2 /* WallpaperIdentityTests.swift in Sources */,
+				AA0000012F600000000OVSR2 /* SourceRoutingTests.swift in Sources */,
+				AA0000012F600000000OVAP2 /* OpenverseMappingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Wallhavend/AspectBucket.swift
+++ b/Wallhavend/AspectBucket.swift
@@ -47,6 +47,23 @@ enum AspectBucket: String, CaseIterable {
 		return snap(aspectRatio: aspect)
 	}
 
+	/// The inverse of `atleastString(for:)`: the pixel floor that string encodes.
+	/// Openverse has to re-derive it because its own `size` filter is a coarse small/medium/large bucket, far too loose to keep a wallpaper sharp.
+	static func minimumDimensions(atleast: String) -> (width: Int, height: Int)? {
+		let parts = atleast.split(separator: "x")
+		guard
+			parts.count == 2,
+			let width = Int(parts[0]),
+			let height = Int(parts[1]),
+			width > 0,
+			height > 0
+		else {
+			return nil
+		}
+
+		return (width, height)
+	}
+
 	static func atleastString(for screens: [NSScreen]) -> String {
 		let dims = screens.map { screen -> (Int, Int) in
 			let scale = screen.backingScaleFactor

--- a/Wallhavend/OpenverseAPI.swift
+++ b/Wallhavend/OpenverseAPI.swift
@@ -1,0 +1,400 @@
+import Foundation
+import SwiftUI
+
+struct OpenverseSearchResponse: Decodable {
+	let pageCount: Int
+	let results: [OpenverseImage]
+
+	enum CodingKeys: String, CodingKey {
+		case pageCount = "page_count"
+		case results
+	}
+}
+
+struct OpenverseImage: Decodable {
+	let id: String
+	let url: String?
+	let width: Int?
+	let height: Int?
+}
+
+/// How permissive an Openverse result's license may be, narrowest first.
+///
+/// Each tier names its licenses outright instead of leaning on Openverse's `license_type` grouping, so the tiers stay strictly nested — widening the filter can only ever add licenses, never swap one out.
+/// Raw values are persisted, so changing one would silently reset a user's choice.
+enum OpenverseLicenseFilter: String, CaseIterable, Identifiable {
+	/// No attribution obligation at all, which is why it's the default.
+	case publicDomain = "public_domain"
+	case permissive
+	case anyCommercial = "any_commercial"
+
+	var id: String { rawValue }
+
+	var apiValue: String {
+		switch self {
+			case .publicDomain:
+				return "cc0,pdm"
+			case .permissive:
+				return "cc0,pdm,by"
+			case .anyCommercial:
+				return "cc0,pdm,by,by-sa,by-nd"
+		}
+	}
+
+	var label: String {
+		switch self {
+			case .publicDomain:
+				return "Public domain"
+			case .permissive:
+				return "Permissive"
+			case .anyCommercial:
+				return "Any commercial use"
+		}
+	}
+}
+
+/// Everything Openverse, kept entirely apart from `WallhavenService` so neither source's quirks leak into the other.
+///
+/// The shape differs from Wallhaven's in two ways that both come from Openverse being an unauthenticated community API: requests are spaced rather than burst, and results are cached per aspect parameter instead of per bucket, because one `wide` page can feed four of our five buckets.
+@MainActor
+final class OpenverseService: ObservableObject {
+	static let shared = OpenverseService()
+
+	/// The trailing slash is load-bearing: without it Openverse answers with a 301 that `URLSession` follows as a GET but the API treats as a different route.
+	private static let baseURL = "https://api.openverse.org/v1/images/"
+
+	/// Openverse indexes 52 sources and most are archival — herbarium sheets and scanned postcards make poor wallpapers — so a search only ever names one of these.
+	///
+	/// Measured 2026-08-22: `flickr` and `nasa` return nothing while `size=large` is in play, because Openverse derives that filter from filesize and their index rows carry none.
+	/// They stay in the list anyway: the live-source strike-off prunes them at runtime for the cost of one request each, and they start contributing again for free if Openverse ever fills that gap.
+	/// `spacex` is absent because it returns nothing under *any* filter combination, including none at all — a dead source rather than a gapped one.
+	nonisolated static let curatedSources = ["flickr", "wikimedia", "nasa", "rawpixel", "stocksnap"]
+
+	/// `saveWallpaper` only accepts JPEG and PNG, so anything else is ruled out server-side instead of downloaded and thrown away.
+	private static let extensions = "jpg,png"
+
+	/// Anonymous requests may ask for 20 results at a time and reach 240 results deep.
+	/// An API key lifts only the first: authenticated callers face the same ceiling on total works per query and merely reach it in fewer round trips, so carrying one would buy no extra wallpapers.
+	private static let pageSize = 20
+	private static let maximumDepth = 240
+	private static let maximumPages = maximumDepth / pageSize
+
+	/// A page can come back full and still admit nothing, so one `fetchCandidate` gets a bounded number of refetches before giving up and letting the router fall through.
+	private static let maximumRefetches = 5
+
+	/// Wallhaven fetches a page and caches it; Openverse's pages are shallower, so a pool fill reaches the network far more often. Spacing is what keeps that burst from earning a 429.
+	private static let minimumRequestSpacing: TimeInterval = 1.5
+
+	/// How long to sit out after Openverse rate-limits us anyway.
+	private static let coolDownDuration: TimeInterval = 600
+
+	/// Results that admit for no active bucket would otherwise pile up until the search key changes.
+	private static let maximumCachedPerAspect = 120
+
+	@AppStorage("openverseLicenseFilter")
+	private var licenseFilterRaw: String = OpenverseLicenseFilter.publicDomain.rawValue
+
+	var licenseFilter: OpenverseLicenseFilter {
+		get {
+			OpenverseLicenseFilter(rawValue: licenseFilterRaw) ?? .publicDomain
+		}
+		set {
+			objectWillChange.send()
+			licenseFilterRaw = newValue.rawValue
+		}
+	}
+
+	/// The query inputs that define a result set. When they change, everything derived from the old ones is stale — including which sources looked dead.
+	private struct SearchKey: Equatable {
+		let keywords: [String]
+		let license: String
+		let mature: Bool
+	}
+
+	/// The 240-result depth cap applies per query, so each keyword, source, and aspect pairing is its own window with its own depth.
+	/// Tracking the page count per pairing is what keeps a shallow window from deciding how deep a deep one may go.
+	private struct PageWindow: Hashable {
+		let keyword: String?
+		let source: String
+		let aspect: String
+	}
+
+	private var lastSearchKey: SearchKey?
+	private var candidatesByAspect: [String: [OpenverseImage]] = [:]
+	private var pageCounts: [PageWindow: Int] = [:]
+	private var liveSources = OpenverseService.curatedSources
+	private var lastRequestAt: Date?
+	private var coolDownUntil: Date?
+
+	/// True while a 429 is still being respected. The router skips Openverse outright rather than queueing behind it.
+	var isCoolingDown: Bool {
+		guard let coolDownUntil else {
+			return false
+		}
+
+		return coolDownUntil > Date()
+	}
+
+	/// Openverse's aspect filter is coarse: three buckets against our five.
+	/// `square` is never requested — no screen snaps to it — and all four landscape buckets have to share `wide`, which is the whole reason the client-side admit gate exists.
+	nonisolated static func aspectParameter(for bucket: AspectBucket) -> String {
+		switch bucket {
+			case .portrait:
+				return "tall"
+			case .ultrawide, .landscape16x9, .landscape16x10, .landscape4x3:
+				return "wide"
+		}
+	}
+
+	/// Whether a result may be saved under `bucket`.
+	///
+	/// Neither of Openverse's own filters is trustworthy here: `wide` covers four of our buckets, and `size` is a coarse small/medium/large bucket derived from filesize.
+	/// Wallpapers are filed by bucket, so the snap check is what makes the requested bucket equal the measured one — a stronger guarantee than Wallhaven's `ratios` filter gives today.
+	/// A result that never reported its dimensions can't prove it qualifies.
+	nonisolated static func admits(width: Int?, height: Int?, minimumWidth: Int, minimumHeight: Int, bucket: AspectBucket) -> Bool {
+		guard let width, let height, width > 0, height > 0 else {
+			return false
+		}
+
+		guard width >= minimumWidth, height >= minimumHeight else {
+			return false
+		}
+
+		return AspectBucket.snap(aspectRatio: Double(width) / Double(height)) == bucket
+	}
+
+	/// Openverse has no random sort, so variety comes from where in the result set a fetch lands.
+	/// The first fetch of a window has to be page 1 — nothing yet says how deep that window goes — and every one after it picks at random within reach.
+	nonisolated static func pageRange(knownPageCount: Int?) -> ClosedRange<Int> {
+		guard let knownPageCount else {
+			return 1...1
+		}
+
+		return 1...max(1, min(knownPageCount, maximumPages))
+	}
+
+	/// Find one Openverse image that fits `bucket`, downloading nothing.
+	/// Returns the filename stem to save it under and the direct image URL for the caller to download.
+	func fetchCandidate(bucket: AspectBucket, atleast: String, blockedStems: Set<String>) async throws -> (stem: String, directURL: String) {
+		clearCachesIfSearchKeyChanged()
+
+		// `atleast` is produced by `AspectBucket.atleastString(for:)`, so this only fails if that contract breaks. Reporting no results lets the router fall through to Wallhaven instead of failing the whole tick.
+		guard let minimum = AspectBucket.minimumDimensions(atleast: atleast) else {
+			throw WallpaperError.noResults
+		}
+
+		let aspect = Self.aspectParameter(for: bucket)
+		var refetches = 0
+
+		while refetches < Self.maximumRefetches {
+			if let candidate = drainCandidate(aspect: aspect, bucket: bucket, minimum: minimum, blockedStems: blockedStems) {
+				return candidate
+			}
+
+			guard !liveSources.isEmpty else {
+				// Every curated source came back empty for these settings; another request would just repeat one of them.
+				break
+			}
+
+			let received = try await refill(aspect: aspect)
+
+			// An empty source is struck off rather than charged to the budget — discovering a dead source shouldn't cost a real attempt.
+			if received > 0 {
+				refetches += 1
+			}
+		}
+
+		throw WallpaperError.noResults
+	}
+
+	/// Take the first cached result that fits this bucket, removing only that one.
+	/// A result that fails here may still fit another bucket sharing the same aspect parameter, so the rest of the cache stays put.
+	private func drainCandidate(
+		aspect: String,
+		bucket: AspectBucket,
+		minimum: (width: Int, height: Int),
+		blockedStems: Set<String>
+	) -> (stem: String, directURL: String)? {
+		guard var cached = candidatesByAspect[aspect] else {
+			return nil
+		}
+
+		for (index, image) in cached.enumerated() {
+			guard let directURL = image.url, !directURL.isEmpty else {
+				continue
+			}
+
+			let stem = WallpaperIdentity(source: .openverse, id: image.id).qualifiedStem
+			guard !blockedStems.contains(stem) else {
+				continue
+			}
+
+			guard Self.admits(width: image.width, height: image.height, minimumWidth: minimum.width, minimumHeight: minimum.height, bucket: bucket) else {
+				continue
+			}
+
+			cached.remove(at: index)
+			candidatesByAspect[aspect] = cached
+
+			return (stem, directURL)
+		}
+
+		return nil
+	}
+
+	/// Fetch one page from one randomly chosen live source and add what it returns to the aspect's cache.
+	/// Returns how many results came back; zero means the source has nothing for the current search key and is struck from the live set.
+	private func refill(aspect: String) async throws -> Int {
+		guard let source = liveSources.randomElement() else {
+			return 0
+		}
+
+		/*
+			One keyword per request, picked at random, rather than the Android sibling's parallel fan-out across every keyword.
+			A pool fill already bursts up to `poolSize * 2 + 2` attempts per bucket, and multiplying that by the keyword count is how an unauthenticated API says no.
+		*/
+		let keyword = WallhavenService.keywords(from: WallhavenService.shared.searchQuery).randomElement()
+		let window = PageWindow(keyword: keyword, source: source, aspect: aspect)
+		let page = Int.random(in: Self.pageRange(knownPageCount: pageCounts[window]))
+
+		let response = try await search(keyword: keyword, source: source, aspect: aspect, page: page)
+
+		pageCounts[window] = response.pageCount
+
+		guard !response.results.isEmpty else {
+			liveSources.removeAll { $0 == source }
+			print("Openverse source \(source) returned nothing for the current settings; skipping it until they change.")
+
+			return 0
+		}
+
+		// The index occasionally carries a plain-http direct URL, which App Transport Security would block partway through the download.
+		let usable = response.results
+			.filter { ($0.url ?? "").hasPrefix("https://") }
+			.shuffled()
+
+		var cached = candidatesByAspect[aspect] ?? []
+		cached.append(contentsOf: usable)
+
+		if cached.count > Self.maximumCachedPerAspect {
+			cached.removeFirst(cached.count - Self.maximumCachedPerAspect)
+		}
+
+		candidatesByAspect[aspect] = cached
+		print("Openverse fetched page \(page) of \(source) for \(aspect): \(response.results.count) results, \(usable.count) usable.")
+
+		return response.results.count
+	}
+
+	private func search(keyword: String?, source: String, aspect: String, page: Int) async throws -> OpenverseSearchResponse {
+		guard !isCoolingDown else {
+			throw WallpaperError.rateLimited
+		}
+
+		var components = URLComponents(string: Self.baseURL)!
+		var items = [
+			URLQueryItem(name: "license", value: licenseFilter.apiValue),
+			URLQueryItem(name: "extension", value: Self.extensions),
+			URLQueryItem(name: "aspect_ratio", value: aspect),
+			URLQueryItem(name: "size", value: "large"),
+			URLQueryItem(name: "source", value: source),
+			URLQueryItem(name: "page", value: String(page)),
+			URLQueryItem(name: "page_size", value: String(Self.pageSize))
+		]
+
+		if let keyword {
+			items.append(URLQueryItem(name: "q", value: keyword))
+		}
+
+		// Openverse's `mature` widens the results rather than restricting them to explicit ones, so it follows the one purity flag that means the same thing.
+		if WallhavenService.shared.includeNSFW {
+			items.append(URLQueryItem(name: "mature", value: "true"))
+		}
+
+		components.queryItems = items
+
+		guard let url = components.url else {
+			throw WallpaperError.invalidURL
+		}
+
+		return try await perform(url: url)
+	}
+
+	/// One HTTP round trip, spaced from the last and retried once if Openverse asks us to wait.
+	private func perform(url: URL) async throws -> OpenverseSearchResponse {
+		for attempt in 0...1 {
+			try await waitForRequestSlot()
+
+			let (data, response) = try await URLSession.shared.data(from: url)
+
+			guard let httpResponse = response as? HTTPURLResponse else {
+				throw WallpaperError.invalidResponse
+			}
+
+			if httpResponse.statusCode == 429 {
+				// Honor one `Retry-After`, then stop asking: a second 429 means the spacing isn't enough right now, and hammering a free community API to find out is the wrong move.
+				if attempt == 0, let delay = Self.retryDelay(from: httpResponse) {
+					print("Openverse asked for \(delay)s before the next request; honoring it once.")
+					try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+
+					continue
+				}
+
+				coolDownUntil = Date().addingTimeInterval(Self.coolDownDuration)
+				print("Openverse rate-limited us; sitting out for \(Int(Self.coolDownDuration / 60)) minutes while Wallhaven covers.")
+
+				throw WallpaperError.rateLimited
+			}
+
+			guard httpResponse.statusCode == 200 else {
+				throw WallpaperError.httpError(httpResponse.statusCode)
+			}
+
+			return try JSONDecoder().decode(OpenverseSearchResponse.self, from: data)
+		}
+
+		throw WallpaperError.rateLimited
+	}
+
+	/// Openverse's `Retry-After` in seconds, clamped so an unreasonable one can't stall a pool fill.
+	private nonisolated static func retryDelay(from response: HTTPURLResponse) -> TimeInterval? {
+		guard
+			let header = response.value(forHTTPHeaderField: "Retry-After"),
+			let seconds = TimeInterval(header)
+		else {
+			return nil
+		}
+
+		return min(max(seconds, 0), 10)
+	}
+
+	private func waitForRequestSlot() async throws {
+		if let lastRequestAt {
+			let remaining = Self.minimumRequestSpacing - Date().timeIntervalSince(lastRequestAt)
+			if remaining > 0 {
+				try await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+			}
+		}
+
+		lastRequestAt = Date()
+	}
+
+	/// Mirrors `WallhavenService.clearCacheIfGlobalParamsChanged()`.
+	/// Resetting `liveSources` matters as much as clearing the cache: a source with nothing for one keyword may be the best one for the next.
+	private func clearCachesIfSearchKeyChanged() {
+		let service = WallhavenService.shared
+		let current = SearchKey(
+			keywords: WallhavenService.keywords(from: service.searchQuery),
+			license: licenseFilter.apiValue,
+			mature: service.includeNSFW
+		)
+
+		if lastSearchKey != current {
+			candidatesByAspect.removeAll()
+			pageCounts.removeAll()
+			liveSources = Self.curatedSources
+			lastSearchKey = current
+			print("Openverse cache invalidated (search key changed).")
+		}
+	}
+}

--- a/Wallhavend/WallpaperError.swift
+++ b/Wallhavend/WallpaperError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum WallpaperError: LocalizedError {
+enum WallpaperError: LocalizedError, Equatable {
 	case invalidURL
 	case invalidResponse
 	case httpError(Int)
@@ -8,6 +8,7 @@ enum WallpaperError: LocalizedError {
 	case unsupportedImageType(String)
 	case invalidImage
 	case noResults
+	case rateLimited
 
 	var errorDescription: String? {
 		switch self {
@@ -25,6 +26,8 @@ enum WallpaperError: LocalizedError {
 				return "Failed to load downloaded image"
 			case .noResults:
 				return "No wallpapers found matching your search criteria"
+			case .rateLimited:
+				return "The image source is rate-limiting requests; it will be skipped for a while"
 		}
 	}
 }

--- a/Wallhavend/WallpaperManager+Prefetch.swift
+++ b/Wallhavend/WallpaperManager+Prefetch.swift
@@ -214,13 +214,13 @@ extension WallpaperManager {
 	private func prefetchOneForBucket(bucket: AspectBucket, atleast: String) async throws -> Bool {
 		let beforeCount = poolsByBucket[bucket.rawValue]?.count ?? 0
 
-		let (stem, data, fileExtension) = try await fetchAndDownload(bucket: bucket, atleast: atleast)
+		let downloaded = try await fetchAndDownload(bucket: bucket, atleast: atleast)
 
 		let wallpaperPath = try await Task.detached(priority: .utility) {
 			try self.saveWallpaper(
-				data: data,
-				id: stem,
-				fileExtension: fileExtension,
+				data: downloaded.data,
+				id: downloaded.stem,
+				fileExtension: downloaded.fileExtension,
 				bucket: bucket
 			)
 		}.value

--- a/Wallhavend/WallpaperManager+Prefetch.swift
+++ b/Wallhavend/WallpaperManager+Prefetch.swift
@@ -41,6 +41,8 @@ extension WallpaperManager {
 		let apiKey: String
 		let poolSize: Int
 		let rotationMode: String
+		let enabledSources: String
+		let openverseLicense: String
 	}
 
 	private func currentPrefetchInputs() -> PrefetchInputs {
@@ -52,7 +54,9 @@ extension WallpaperManager {
 			purity: service.purityString,
 			apiKey: service.apiKey,
 			poolSize: poolSize,
-			rotationMode: rotationMode.rawValue
+			rotationMode: rotationMode.rawValue,
+			enabledSources: Self.encodeSources(enabledSources),
+			openverseLicense: OpenverseService.shared.licenseFilter.rawValue
 		)
 	}
 
@@ -210,12 +214,12 @@ extension WallpaperManager {
 	private func prefetchOneForBucket(bucket: AspectBucket, atleast: String) async throws -> Bool {
 		let beforeCount = poolsByBucket[bucket.rawValue]?.count ?? 0
 
-		let wallpaper = try await WallhavenService.shared.fetchRandomWallpaper(ratios: bucket.rawValue, atleast: atleast)
-		let (data, fileExtension) = try await downloadWallpaper(from: wallpaper.path)
+		let (stem, data, fileExtension) = try await fetchAndDownload(bucket: bucket, atleast: atleast)
+
 		let wallpaperPath = try await Task.detached(priority: .utility) {
 			try self.saveWallpaper(
 				data: data,
-				id: wallpaper.id,
+				id: stem,
 				fileExtension: fileExtension,
 				bucket: bucket
 			)

--- a/Wallhavend/WallpaperManager+Sources.swift
+++ b/Wallhavend/WallpaperManager+Sources.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+extension WallpaperManager {
+	/// Fetch a wallpaper from whichever enabled source produces one first, and bring its bytes back with it.
+	///
+	/// Fetch and download live together on purpose: an Openverse index entry can name a URL that no longer serves an image, and only a caller that sees both steps can fall through to Wallhaven when that happens.
+	/// The returned stem is what the file is saved under — bare for Wallhaven, `openverse_`-qualified otherwise — so `saveWallpaper` needs no idea which source it came from.
+	func fetchAndDownload(bucket: AspectBucket, atleast: String) async throws -> (stem: String, data: Data, fileExtension: String) {
+		let order = Self.sourceOrder(enabled: enabledSources, openverseCoolingDown: OpenverseService.shared.isCoolingDown)
+
+		guard !order.isEmpty else {
+			// Openverse was the only enabled source and it's sitting out a 429. With one source there's nothing to fall through to, and silence would be indistinguishable from a broken app.
+			throw WallpaperError.rateLimited
+		}
+
+		var failures: [Error] = []
+
+		for source in order {
+			do {
+				let candidate = try await fetchCandidate(from: source, bucket: bucket, atleast: atleast)
+				let (data, fileExtension) = try await downloadWallpaper(from: candidate.directURL)
+
+				return (candidate.stem, data, fileExtension)
+			} catch let error as CancellationError {
+				// Cancellation isn't a source failing; it's the whole fill being called off.
+				throw error
+			} catch {
+				print("\(source.displayName) couldn't supply a wallpaper for \(bucket.rawValue): \(error)")
+				failures.append(error)
+			}
+		}
+
+		throw Self.mostInformative(failures)
+	}
+
+	private func fetchCandidate(from source: WallpaperSource, bucket: AspectBucket, atleast: String) async throws -> (stem: String, directURL: String) {
+		switch source {
+			case .wallhaven:
+				let wallpaper = try await WallhavenService.shared.fetchRandomWallpaper(ratios: bucket.rawValue, atleast: atleast)
+
+				// Wallhaven stems stay bare forever, so its id already is the stem (see `WallpaperIdentity`).
+				return (wallpaper.id, wallpaper.path)
+			case .openverse:
+				return try await OpenverseService.shared.fetchCandidate(
+					bucket: bucket,
+					atleast: atleast,
+					blockedStems: WallhavenService.shared.blockedIds
+				)
+		}
+	}
+
+	/// The order to try sources in for one bucket fetch.
+	///
+	/// Shuffled rather than ranked, so with both enabled neither one dominates the pool.
+	/// Openverse drops out entirely while it's cooling down from a 429 — trying it would only burn a request to be told the same thing again.
+	nonisolated static func sourceOrder(enabled: Set<WallpaperSource>, openverseCoolingDown: Bool) -> [WallpaperSource] {
+		enabled
+			.filter { source in
+				source != .openverse || !openverseCoolingDown
+			}
+			.shuffled()
+	}
+
+	/// Pick the error worth surfacing when every source failed.
+	///
+	/// "No wallpapers found" is the least informative outcome — it's what an over-narrow search looks like, and it hides a real failure standing behind it — so any other error wins.
+	nonisolated static func mostInformative(_ errors: [Error]) -> Error {
+		let informative = errors.first { error in
+			guard let wallpaperError = error as? WallpaperError else {
+				return true
+			}
+
+			return wallpaperError != .noResults
+		}
+
+		return informative ?? errors.first ?? WallpaperError.noResults
+	}
+}

--- a/Wallhavend/WallpaperManager+Sources.swift
+++ b/Wallhavend/WallpaperManager+Sources.swift
@@ -1,11 +1,19 @@
 import Foundation
 
 extension WallpaperManager {
+	/// A wallpaper's bytes together with the filename stem to save them under.
+	///
+	/// The stem is bare for Wallhaven and `openverse_`-qualified otherwise, so `saveWallpaper` never needs to know which source produced it.
+	struct DownloadedWallpaper {
+		let stem: String
+		let data: Data
+		let fileExtension: String
+	}
+
 	/// Fetch a wallpaper from whichever enabled source produces one first, and bring its bytes back with it.
 	///
 	/// Fetch and download live together on purpose: an Openverse index entry can name a URL that no longer serves an image, and only a caller that sees both steps can fall through to Wallhaven when that happens.
-	/// The returned stem is what the file is saved under — bare for Wallhaven, `openverse_`-qualified otherwise — so `saveWallpaper` needs no idea which source it came from.
-	func fetchAndDownload(bucket: AspectBucket, atleast: String) async throws -> (stem: String, data: Data, fileExtension: String) {
+	func fetchAndDownload(bucket: AspectBucket, atleast: String) async throws -> DownloadedWallpaper {
 		let order = Self.sourceOrder(enabled: enabledSources, openverseCoolingDown: OpenverseService.shared.isCoolingDown)
 
 		guard !order.isEmpty else {
@@ -20,7 +28,7 @@ extension WallpaperManager {
 				let candidate = try await fetchCandidate(from: source, bucket: bucket, atleast: atleast)
 				let (data, fileExtension) = try await downloadWallpaper(from: candidate.directURL)
 
-				return (candidate.stem, data, fileExtension)
+				return DownloadedWallpaper(stem: candidate.stem, data: data, fileExtension: fileExtension)
 			} catch let error as CancellationError {
 				// Cancellation isn't a source failing; it's the whole fill being called off.
 				throw error

--- a/Wallhavend/WallpaperManager+Wallpaper.swift
+++ b/Wallhavend/WallpaperManager+Wallpaper.swift
@@ -102,13 +102,13 @@ extension WallpaperManager {
 	private func updateWallpaperForBucket(bucket: AspectBucket, screens: [NSScreen]) async {
 		do {
 			let atleast = AspectBucket.atleastString(for: screens)
-			let (stem, data, fileExtension) = try await fetchAndDownload(bucket: bucket, atleast: atleast)
+			let downloaded = try await fetchAndDownload(bucket: bucket, atleast: atleast)
 
 			let wallpaperPath = try await Task.detached(priority: .userInitiated) {
 				try self.saveWallpaper(
-					data: data,
-					id: stem,
-					fileExtension: fileExtension,
+					data: downloaded.data,
+					id: downloaded.stem,
+					fileExtension: downloaded.fileExtension,
 					bucket: bucket
 				)
 			}.value

--- a/Wallhavend/WallpaperManager+Wallpaper.swift
+++ b/Wallhavend/WallpaperManager+Wallpaper.swift
@@ -102,16 +102,12 @@ extension WallpaperManager {
 	private func updateWallpaperForBucket(bucket: AspectBucket, screens: [NSScreen]) async {
 		do {
 			let atleast = AspectBucket.atleastString(for: screens)
-			let wallpaper = try await WallhavenService.shared.fetchRandomWallpaper(
-				ratios: bucket.rawValue,
-				atleast: atleast
-			)
+			let (stem, data, fileExtension) = try await fetchAndDownload(bucket: bucket, atleast: atleast)
 
-			let (data, fileExtension) = try await downloadWallpaper(from: wallpaper.path)
 			let wallpaperPath = try await Task.detached(priority: .userInitiated) {
 				try self.saveWallpaper(
 					data: data,
-					id: wallpaper.id,
+					id: stem,
 					fileExtension: fileExtension,
 					bucket: bucket
 				)

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -59,6 +59,8 @@ class WallpaperManager: ObservableObject {
 
 		_rotationMode = Published(initialValue: storedMode)
 
+		_enabledSources = Published(initialValue: Self.decodeSources(UserDefaults.standard.string(forKey: "enabledSources")))
+
 		setupSessionObservers()
 		setupScreenLockObservers()
 		setupNetworkObserver()
@@ -87,6 +89,32 @@ class WallpaperManager: ObservableObject {
 		didSet {
 			UserDefaults.standard.set(rotationMode.rawValue, forKey: "rotationMode")
 		}
+	}
+
+	/// Which sources automatic rotation and pool fills may draw from.
+	/// Defaults to Wallhaven alone, so an install that never opts in keeps exactly today's behavior and today's network traffic.
+	@Published var enabledSources: Set<WallpaperSource> = [.wallhaven] {
+		didSet {
+			UserDefaults.standard.set(Self.encodeSources(enabledSources), forKey: "enabledSources")
+		}
+	}
+
+	/// Comma-joined raw keys, sorted so the stored string doesn't churn on every write.
+	nonisolated static func encodeSources(_ sources: Set<WallpaperSource>) -> String {
+		sources.map { $0.rawValue }
+			.sorted()
+			.joined(separator: ",")
+	}
+
+	/// A missing, empty, or unrecognizable value falls back to Wallhaven.
+	/// Everything downstream assumes at least one source is enabled, and Wallhaven is the one that needs no opt-in.
+	nonisolated static func decodeSources(_ raw: String?) -> Set<WallpaperSource> {
+		let parsed = Set(
+			(raw ?? "").split(separator: ",")
+				.compactMap { WallpaperSource(rawValue: String($0)) }
+		)
+
+		return if parsed.isEmpty { [.wallhaven] } else { parsed }
 	}
 
 	@Published

--- a/WallhavendTests/AspectBucketTests.swift
+++ b/WallhavendTests/AspectBucketTests.swift
@@ -47,4 +47,23 @@ final class AspectBucketTests: XCTestCase {
 		XCTAssertEqual(AspectBucket.landscape4x3.label, "Landscape (4:3)")
 		XCTAssertEqual(AspectBucket.portrait.label, "Portrait (9:16)")
 	}
+
+	func testMinimumDimensionsInvertsAtleastString() {
+		let parsed = AspectBucket.minimumDimensions(atleast: "3024x1964")
+
+		XCTAssertEqual(parsed?.width, 3024)
+		XCTAssertEqual(parsed?.height, 1964)
+	}
+
+	func testMinimumDimensionsRejectsMalformedStrings() {
+		XCTAssertNil(AspectBucket.minimumDimensions(atleast: "3024"))
+		XCTAssertNil(AspectBucket.minimumDimensions(atleast: "3024x1964x2"))
+		XCTAssertNil(AspectBucket.minimumDimensions(atleast: "wide x tall"))
+		XCTAssertNil(AspectBucket.minimumDimensions(atleast: ""))
+	}
+
+	func testMinimumDimensionsRejectsNonPositiveSizes() {
+		XCTAssertNil(AspectBucket.minimumDimensions(atleast: "0x1964"))
+		XCTAssertNil(AspectBucket.minimumDimensions(atleast: "3024x0"))
+	}
 }

--- a/WallhavendTests/OpenverseMappingTests.swift
+++ b/WallhavendTests/OpenverseMappingTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+@testable import Wallhavend
+
+/// The pure mapping layer between our buckets and Openverse's query vocabulary.
+/// Nothing here touches the network: the request-shaping decisions are the part worth pinning down, and Openverse is a shared community API that CI's three-OS matrix has no business hammering on every push.
+final class OpenverseMappingTests: XCTestCase {
+	// MARK: - aspectParameter: five buckets onto Openverse's coarser filter
+
+	func testPortraitAsksForTall() {
+		XCTAssertEqual(OpenverseService.aspectParameter(for: .portrait), "tall")
+	}
+
+	func testEveryLandscapeBucketSharesWide() {
+		XCTAssertEqual(OpenverseService.aspectParameter(for: .ultrawide), "wide")
+		XCTAssertEqual(OpenverseService.aspectParameter(for: .landscape16x9), "wide")
+		XCTAssertEqual(OpenverseService.aspectParameter(for: .landscape16x10), "wide")
+		XCTAssertEqual(OpenverseService.aspectParameter(for: .landscape4x3), "wide")
+	}
+
+	func testSquareIsNeverRequested() {
+		// No screen snaps to square, so asking for it would only spend requests on results nothing can use.
+		for bucket in AspectBucket.allCases {
+			XCTAssertNotEqual(OpenverseService.aspectParameter(for: bucket), "square")
+		}
+	}
+
+	// MARK: - admits: the client-side gate that `wide` and `size=large` are too coarse to be
+
+	func testAdmitsWhenBucketAndSizeBothMatch() {
+		XCTAssertTrue(
+			OpenverseService.admits(width: 3840, height: 2400, minimumWidth: 3024, minimumHeight: 1964, bucket: .landscape16x10)
+		)
+	}
+
+	func testRejectsRightSizeButWrongBucket() {
+		// 3840x2160 is comfortably large enough, but it snaps to 16x9 — filed under 16x10 it would letterbox.
+		XCTAssertFalse(
+			OpenverseService.admits(width: 3840, height: 2160, minimumWidth: 3024, minimumHeight: 1964, bucket: .landscape16x10)
+		)
+	}
+
+	func testRejectsRightBucketButTooSmall() {
+		XCTAssertFalse(
+			OpenverseService.admits(width: 2560, height: 1600, minimumWidth: 3024, minimumHeight: 1964, bucket: .landscape16x10)
+		)
+	}
+
+	func testRejectsWhenOnlyOneDimensionClears() {
+		XCTAssertFalse(
+			OpenverseService.admits(width: 4000, height: 1200, minimumWidth: 1920, minimumHeight: 1080, bucket: .landscape16x9)
+		)
+	}
+
+	func testRejectsMissingDimensions() {
+		// A result that never reported its size can't prove it qualifies.
+		XCTAssertFalse(
+			OpenverseService.admits(width: nil, height: 2160, minimumWidth: 1920, minimumHeight: 1080, bucket: .landscape16x9)
+		)
+
+		XCTAssertFalse(
+			OpenverseService.admits(width: 3840, height: nil, minimumWidth: 1920, minimumHeight: 1080, bucket: .landscape16x9)
+		)
+	}
+
+	func testRejectsZeroDimensions() {
+		XCTAssertFalse(
+			OpenverseService.admits(width: 0, height: 0, minimumWidth: 0, minimumHeight: 0, bucket: .landscape16x9)
+		)
+	}
+
+	func testAdmitsPortrait() {
+		XCTAssertTrue(
+			OpenverseService.admits(width: 2160, height: 3840, minimumWidth: 1080, minimumHeight: 1920, bucket: .portrait)
+		)
+	}
+
+	// MARK: - pageRange: where in a result window a fetch may land
+
+	func testFirstFetchOfAWindowMustBePageOne() {
+		// Nothing yet says how deep the window goes, so page 1 is the only page known to exist.
+		XCTAssertEqual(OpenverseService.pageRange(knownPageCount: nil), 1...1)
+	}
+
+	func testKnownPageCountOpensTheWholeWindow() {
+		XCTAssertEqual(OpenverseService.pageRange(knownPageCount: 12), 1...12)
+		XCTAssertEqual(OpenverseService.pageRange(knownPageCount: 5), 1...5)
+	}
+
+	func testDeeperWindowsAreCappedAtTheAnonymousCeiling() {
+		// Anonymous access reaches 240 results at 20 per page, whatever the response claims.
+		XCTAssertEqual(OpenverseService.pageRange(knownPageCount: 30), 1...12)
+	}
+
+	func testEmptyWindowStillYieldsAValidRange() {
+		XCTAssertEqual(OpenverseService.pageRange(knownPageCount: 0), 1...1)
+	}
+
+	// MARK: - license tiers
+
+	func testApiValuesAreExact() {
+		XCTAssertEqual(OpenverseLicenseFilter.publicDomain.apiValue, "cc0,pdm")
+		XCTAssertEqual(OpenverseLicenseFilter.permissive.apiValue, "cc0,pdm,by")
+		XCTAssertEqual(OpenverseLicenseFilter.anyCommercial.apiValue, "cc0,pdm,by,by-sa,by-nd")
+	}
+
+	func testTiersAreStrictlyNested() {
+		// Widening the filter must only ever add licenses. If a tier ever swapped one out, a user widening their choice would silently lose results they already had.
+		let tiers = OpenverseLicenseFilter.allCases.map { Set($0.apiValue.split(separator: ",")) }
+
+		for (narrower, wider) in zip(tiers, tiers.dropFirst()) {
+			XCTAssertTrue(narrower.isStrictSubset(of: wider))
+		}
+	}
+
+	func testDefaultTierCarriesNoAttributionObligation() {
+		XCTAssertEqual(OpenverseLicenseFilter.allCases.first, .publicDomain)
+	}
+
+	// MARK: - the curated source list
+
+	func testCuratedSourcesExcludeSpacex() {
+		// Measured 2026-08-22: spacex returns nothing under any filter combination, including none at all.
+		XCTAssertFalse(OpenverseService.curatedSources.contains("spacex"))
+	}
+
+	func testCuratedSourcesAreTheOnesWorthAsking() {
+		XCTAssertEqual(OpenverseService.curatedSources, ["flickr", "wikimedia", "nasa", "rawpixel", "stocksnap"])
+	}
+}

--- a/WallhavendTests/SourceRoutingTests.swift
+++ b/WallhavendTests/SourceRoutingTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import Wallhavend
+
+/// The routing decisions that sit between "a bucket needs a wallpaper" and "some source produced one".
+final class SourceRoutingTests: XCTestCase {
+	// MARK: - sourceOrder: who gets asked, in what order
+
+	func testWallhavenOnlyYieldsWallhaven() {
+		XCTAssertEqual(
+			WallpaperManager.sourceOrder(enabled: [.wallhaven], openverseCoolingDown: false),
+			[.wallhaven]
+		)
+	}
+
+	func testBothEnabledYieldsBothInSomeOrder() {
+		let order = WallpaperManager.sourceOrder(enabled: [.wallhaven, .openverse], openverseCoolingDown: false)
+
+		XCTAssertEqual(order.count, 2)
+		XCTAssertEqual(Set(order), [.wallhaven, .openverse])
+	}
+
+	func testCoolingDownOpenverseIsSkipped() {
+		// Asking a source that just rate-limited us only spends a request to hear the same answer.
+		XCTAssertEqual(
+			WallpaperManager.sourceOrder(enabled: [.wallhaven, .openverse], openverseCoolingDown: true),
+			[.wallhaven]
+		)
+	}
+
+	func testCoolingDownIrrelevantToWallhaven() {
+		XCTAssertEqual(
+			WallpaperManager.sourceOrder(enabled: [.wallhaven], openverseCoolingDown: true),
+			[.wallhaven]
+		)
+	}
+
+	func testOpenverseAloneAndCoolingDownLeavesNobodyToAsk() {
+		// The router turns this empty order into a rate-limited error rather than a silent no-op — with one source there's nothing to fall through to.
+		XCTAssertTrue(
+			WallpaperManager.sourceOrder(enabled: [.openverse], openverseCoolingDown: true).isEmpty
+		)
+	}
+
+	// MARK: - mostInformative: which failure is worth showing
+
+	func testRealErrorBeatsNoResults() {
+		let picked = WallpaperManager.mostInformative([WallpaperError.noResults, WallpaperError.httpError(503)])
+
+		XCTAssertEqual(picked as? WallpaperError, .httpError(503))
+	}
+
+	func testRealErrorWinsEvenWhenItComesSecond() {
+		let picked = WallpaperManager.mostInformative([WallpaperError.noResults, WallpaperError.rateLimited])
+
+		XCTAssertEqual(picked as? WallpaperError, .rateLimited)
+	}
+
+	func testAllNoResultsStaysNoResults() {
+		let picked = WallpaperManager.mostInformative([WallpaperError.noResults, WallpaperError.noResults])
+
+		XCTAssertEqual(picked as? WallpaperError, .noResults)
+	}
+
+	func testNoFailuresAtAllStillProducesAnError() {
+		// Only reachable if the order was non-empty but nothing ran; the caller still needs something to throw.
+		XCTAssertEqual(WallpaperManager.mostInformative([]) as? WallpaperError, .noResults)
+	}
+
+	func testForeignErrorsCountAsInformative() {
+		let picked = WallpaperManager.mostInformative([WallpaperError.noResults, URLError(.timedOut)])
+
+		XCTAssertEqual(picked as? URLError, URLError(.timedOut))
+	}
+
+	// MARK: - enabledSources persistence
+
+	func testEncodeIsSortedAndCommaJoined() {
+		XCTAssertEqual(WallpaperManager.encodeSources([.openverse, .wallhaven]), "openverse,wallhaven")
+		XCTAssertEqual(WallpaperManager.encodeSources([.wallhaven]), "wallhaven")
+	}
+
+	func testRoundTripsThroughStorage() {
+		for sources in [Set<WallpaperSource>([.wallhaven]), [.openverse], [.wallhaven, .openverse]] {
+			XCTAssertEqual(WallpaperManager.decodeSources(WallpaperManager.encodeSources(sources)), sources)
+		}
+	}
+
+	func testUnwrittenSettingFallsBackToWallhaven() {
+		// A fresh install has nothing stored, and it must behave exactly as it did before sources existed.
+		XCTAssertEqual(WallpaperManager.decodeSources(nil), [.wallhaven])
+	}
+
+	func testUnusableStoredValuesFallBackToWallhaven() {
+		// Everything downstream assumes at least one source is enabled, so an empty or garbled set can't be taken at face value.
+		XCTAssertEqual(WallpaperManager.decodeSources(""), [.wallhaven])
+		XCTAssertEqual(WallpaperManager.decodeSources("flickr,unsplash"), [.wallhaven])
+	}
+
+	func testUnknownKeysAreDroppedButKnownOnesSurvive() {
+		XCTAssertEqual(WallpaperManager.decodeSources("openverse,pexels"), [.openverse])
+	}
+}


### PR DESCRIPTION
Second of Part B's three PRs. B1 taught the app to recover a wallpaper's source from its filename stem; this builds the thing that actually talks to Openverse — and leaves it unreachable. `enabledSources` defaults to Wallhaven alone and nothing in the UI can change it until the source picker lands in B3, so a default install makes the same requests and rotates the same way it does today.

## The router

Both fetch call sites (`updateWallpaperForBucket`, `prefetchOneForBucket`) now go through `fetchAndDownload` in a new `WallpaperManager+Sources.swift` instead of calling `WallhavenService` directly. It owns fetch *and* download together on purpose: an Openverse index entry can name a URL that no longer serves an image, and only a caller that sees both steps can fall through to Wallhaven when that happens. Enabled sources are shuffled per bucket fetch, first success wins, and when every source fails the error surfaced is whichever one isn't "no results" — that outcome is what an over-narrow search looks like and it hides real failures standing behind it.

`saveWallpaper` is untouched. The router returns the stem to save under — bare for Wallhaven, `openverse_`-qualified otherwise — so nothing downstream learns about sources, and pin/block/pool membership stays exact string equality.

## The engine

`OpenverseService` shapes its requests around Openverse being an unauthenticated community API:

- **One keyword and one source per request**, both picked at random, rather than the Android sibling's parallel fan-out. A pool fill already bursts up to `poolSize * 2 + 2` attempts per bucket; multiplying that by the keyword count is how a free API says no.
- **Results cached per aspect parameter, admitted at drain.** One page of `wide` results feeds all four landscape buckets without new requests, because whether a result qualifies depends on the bucket asking.
- **Page windows keyed `(keyword, source, aspect)`.** The 240-result cap is per query, so a shallow window must not decide how deep a deep one may go. Page 1 first, then random within reach — the substitute for Openverse having no random sort.
- **1.5 s minimum spacing**, one honored `Retry-After` on a 429, then a cool-down the router skips Openverse during. Degradation is silent; Wallhaven covers.

Openverse's own filters are too coarse to trust — `aspect_ratio=wide` covers four of our five buckets, and `size` is a filesize-derived small/medium/large bucket. A client-side gate re-checks real pixel dimensions and requires the image to snap to the bucket it will be filed under. That makes the requested bucket equal the measured one, which is a *stronger* guarantee than Wallhaven's `ratios` filter gives today.

## What measuring the live index changed

Probed the API directly (~70 requests, 1.5 s apart, no 429) rather than trusting the port's assumptions:

| Source | Under `size=large` | Cause |
|---|---|---|
| `wikimedia`, `rawpixel`, `stocksnap` | 240 results | — |
| `flickr` (536M indexed), `nasa` | **0 results** | Openverse derives `size` from filesize, which their index rows lack |
| `spacex` | **0 results with no filters at all** | dead source |

So `spacex` is dropped from the curated list; `flickr` and `nasa` stay. The runtime strike-off prunes them for the cost of one request each, and they start contributing again for free if that index gap ever closes. Dropping `size=large` to "unlock" them was tempting but measurably wrong — they admit 0/20 either way, and keeping it raises the overall admit rate from 26% to 45%.

Two other measurements are baked into the code: `page_count` is 12 and `result_count` exactly 240 for every live source, and page 13 returns HTTP 401, so `pageRange`'s cap at 12 is load-bearing rather than cosmetic.

Expect Openverse to contribute well on 16:10 displays (45% admit rate on a 14" MBP) and sparsely on 16:9 — only 3–5 of every 100 `wide` results snap to 16:9. Relaxing the size floor doesn't help that, so the strict gate costs nothing it would recover; Wallhaven fall-through covers the gap.

## Notes

- No live-network tests for Openverse. `WallhavendTests` does hit Wallhaven for real, but CI runs a three-OS matrix on every push, and tripling anonymous rate-limited calls against a shared community API isn't worth coverage the pure statics already give.
- `AspectBucket` gains `minimumDimensions(atleast:)`, the inverse of `atleastString(for:)`, co-located with the function it inverts.
- `WallpaperError` gains `.rateLimited` and conforms to `Equatable`.
- No version bump — the release comes after B3.