### PR TITLE
feat: make Openverse selectable from the settings window

### DIFF
--- a/Wallhavend/AdvancedTab.swift
+++ b/Wallhavend/AdvancedTab.swift
@@ -22,6 +22,11 @@ struct AdvancedTab: View {
 		!wallhavenService.pinnedIds.isEmpty
 	}
 
+	/// The API key buys nothing while Wallhaven isn't being asked for wallpapers, so the field goes away with it. Rotation and the pool are cross-source and stay put.
+	private var isWallhavenEnabled: Bool {
+		wallpaperManager.enabledSources.contains(.wallhaven)
+	}
+
 	/// Shows the stored mode as-is; the setter still refuses to enter Pinned only while nothing is pinned (the radio option is disabled then, too).
 	private var rotationModeBinding: Binding<RotationMode> {
 		Binding(
@@ -89,13 +94,15 @@ struct AdvancedTab: View {
 				.foregroundColor(.secondary)
 		}
 
-		VStack(alignment: .leading, spacing: 6) {
-			Text("API Key")
-				.font(.headline)
+		if isWallhavenEnabled {
+			VStack(alignment: .leading, spacing: 6) {
+				Text("API Key")
+					.font(.headline)
 
-			SecureField("Your Wallhaven API key (optional)", text: apiKeyBinding)
-				.textFieldStyle(.roundedBorder)
-				.font(.system(.body, design: .monospaced))
+				SecureField("Your Wallhaven API key (optional)", text: apiKeyBinding)
+					.textFieldStyle(.roundedBorder)
+					.font(.system(.body, design: .monospaced))
+			}
 		}
 	}
 }

--- a/Wallhavend/AppDelegate.swift
+++ b/Wallhavend/AppDelegate.swift
@@ -58,6 +58,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 		let contentView = ContentView()
 			.environmentObject(wallpaperManager)
 			.environmentObject(WallhavenService.shared)
+			.environmentObject(OpenverseService.shared)
 
 		let hostingView = NSHostingView(rootView: contentView)
 		hostingView.frame = NSRect(x: 0, y: 0, width: 500, height: 540)

--- a/Wallhavend/BlockedTab.swift
+++ b/Wallhavend/BlockedTab.swift
@@ -55,12 +55,19 @@ private struct BlockedRow: View {
 					revealed = true
 				}
 
-			if let pageURL = identity.pageURL {
-				Link(id, destination: pageURL)
-					.font(.system(.body, design: .monospaced))
-			} else {
-				Text(id)
-					.font(.system(.body, design: .monospaced))
+			// The bare id rather than the stored stem: `openverse_` in front of a 36-character UUID crowds the row and repeats what the source line already says.
+			VStack(alignment: .leading, spacing: 2) {
+				if let pageURL = identity.pageURL {
+					Link(identity.id, destination: pageURL)
+						.font(.system(.body, design: .monospaced))
+				} else {
+					Text(identity.id)
+						.font(.system(.body, design: .monospaced))
+				}
+
+				Text(identity.source.displayName)
+					.font(.caption)
+					.foregroundColor(.secondary)
 			}
 
 			Spacer()

--- a/Wallhavend/ContentTab.swift
+++ b/Wallhavend/ContentTab.swift
@@ -1,7 +1,9 @@
 import SwiftUI
 
 struct ContentTab: View {
+	@EnvironmentObject var wallpaperManager: WallpaperManager
 	@EnvironmentObject var wallhavenService: WallhavenService
+	@EnvironmentObject var openverseService: OpenverseService
 
 	private var searchQueryBinding: Binding<String> {
 		Binding(
@@ -31,6 +33,13 @@ struct ContentTab: View {
 		)
 	}
 
+	private var licenseBinding: Binding<OpenverseLicenseFilter> {
+		Binding(
+			get: { openverseService.licenseFilter },
+			set: { openverseService.licenseFilter = $0 }
+		)
+	}
+
 	private func categoryBinding(_ category: WallhavenCategory) -> Binding<Bool> {
 		Binding(
 			get: { wallhavenService.selectedCategories.contains(category) },
@@ -47,7 +56,54 @@ struct ContentTab: View {
 		)
 	}
 
+	/// Every flip routes through `toggleKeepingOne`, so a refused removal leaves the stored set — and with it the checkbox — exactly where it was.
+	private func sourceBinding(_ source: WallpaperSource) -> Binding<Bool> {
+		Binding(
+			get: { wallpaperManager.enabledSources.contains(source) },
+			set: { _ in
+				wallpaperManager.enabledSources = WallpaperSource.toggleKeepingOne(source, in: wallpaperManager.enabledSources)
+			}
+		)
+	}
+
+	private var isWallhavenEnabled: Bool {
+		wallpaperManager.enabledSources.contains(.wallhaven)
+	}
+
+	private var isOpenverseEnabled: Bool {
+		wallpaperManager.enabledSources.contains(.openverse)
+	}
+
+	/// The caption under Content Rating.
+	///
+	/// The three toggles are Wallhaven's purity bits, and Openverse understands only the NSFW one, which it maps onto allowing mature results (`OpenverseAPI.swift`).
+	/// So the caption shows up only once Openverse is enabled — a Wallhaven-only install sees exactly the screen it saw before sources existed — and its job is to say which toggles the enabled sources actually read.
+	static func contentRatingCaption(enabled: Set<WallpaperSource>) -> String? {
+		guard enabled.contains(.openverse) else {
+			return nil
+		}
+
+		return if enabled.contains(.wallhaven) {
+			"Wallhaven honors all three. Openverse reads only NSFW, which lets mature results through."
+		} else {
+			"Openverse reads only NSFW, which lets mature results through — SFW and Sketchy apply to Wallhaven alone."
+		}
+	}
+
+	private var contentRatingCaption: String? {
+		Self.contentRatingCaption(enabled: wallpaperManager.enabledSources)
+	}
+
 	var body: some View {
+		VStack(alignment: .leading, spacing: 8) {
+			Text("Sources")
+				.font(.headline)
+
+			ForEach(WallpaperSource.allCases, id: \.self) { source in
+				Toggle(source.displayName, isOn: sourceBinding(source))
+			}
+		}
+
 		VStack(alignment: .leading, spacing: 6) {
 			Text("Search")
 				.font(.headline)
@@ -56,16 +112,7 @@ struct ContentTab: View {
 				.textFieldStyle(.roundedBorder)
 		}
 
-		HStack(alignment: .top, spacing: 32) {
-			VStack(alignment: .leading, spacing: 8) {
-				Text("Content Rating")
-					.font(.headline)
-
-				Toggle("SFW", isOn: sfwBinding)
-				Toggle("Sketchy", isOn: sketchyBinding)
-				Toggle("NSFW", isOn: nsfwBinding)
-			}
-
+		if isWallhavenEnabled {
 			VStack(alignment: .leading, spacing: 8) {
 				Text("Categories")
 					.font(.headline)
@@ -76,6 +123,41 @@ struct ContentTab: View {
 						isOn: categoryBinding(category)
 					)
 				}
+			}
+		}
+
+		VStack(alignment: .leading, spacing: 8) {
+			Text("Content Rating")
+				.font(.headline)
+
+			Toggle("SFW", isOn: sfwBinding)
+			Toggle("Sketchy", isOn: sketchyBinding)
+			Toggle("NSFW", isOn: nsfwBinding)
+
+			if let contentRatingCaption {
+				Text(contentRatingCaption)
+					.font(.caption)
+					.foregroundColor(.secondary)
+			}
+		}
+
+		if isOpenverseEnabled {
+			VStack(alignment: .leading, spacing: 6) {
+				Text("License")
+					.font(.headline)
+
+				Picker("License", selection: licenseBinding) {
+					ForEach(OpenverseLicenseFilter.allCases) { filter in
+						Text(filter.label)
+							.tag(filter)
+					}
+				}
+				.labelsHidden()
+				.pickerStyle(.radioGroup)
+
+				Text("Public domain asks nothing of you. The wider tiers return more wallpapers but expect the creator to be credited if you reuse them.")
+					.font(.caption)
+					.foregroundColor(.secondary)
 			}
 		}
 	}

--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -17,6 +17,12 @@ struct ContentView: View {
 		wallpaperManager.isOnline || wallpaperManager.isRunning || wallpaperManager.rotationMode == .pinnedOnly
 	}
 
+	/// Credits for the sources wallpapers can currently arrive from, in a fixed order so they don't reshuffle as the set changes.
+	/// Openverse's terms require its line for as long as its wallpapers can show up, which is exactly while it's enabled.
+	private var attributedSources: [WallpaperSource] {
+		WallpaperSource.allCases.filter { wallpaperManager.enabledSources.contains($0) }
+	}
+
 	var body: some View {
 		VStack(spacing: 0) {
 			Picker("", selection: $selectedTab) {
@@ -90,6 +96,14 @@ struct ContentView: View {
 				if wallpaperManager.lastUpdated != nil {
 					Text("Last updated: \(wallpaperManager.formattedLastUpdated)")
 						.font(.caption)
+				}
+
+				ForEach(attributedSources, id: \.self) { source in
+					if let homeURL = source.homeURL {
+						Link(source.attribution, destination: homeURL)
+							.font(.caption)
+							.foregroundColor(.secondary)
+					}
 				}
 			}
 			.padding()

--- a/Wallhavend/WallpaperSource.swift
+++ b/Wallhavend/WallpaperSource.swift
@@ -14,6 +14,43 @@ enum WallpaperSource: String, CaseIterable {
 				return "Openverse"
 		}
 	}
+
+	/// What the source asks to be credited with wherever its wallpapers are used.
+	/// Openverse's terms require stating that the app is neither endorsed nor certified by them, so its line is an obligation rather than a courtesy — the wording is theirs and shouldn't be paraphrased.
+	var attribution: String {
+		switch self {
+			case .wallhaven:
+				return "Powered by wallhaven.cc"
+			case .openverse:
+				return "Made using Openverse — not endorsed or certified by Openverse"
+		}
+	}
+
+	/// Where the credit links to.
+	var homeURL: URL? {
+		switch self {
+			case .wallhaven:
+				return URL(string: "https://wallhaven.cc")
+			case .openverse:
+				return URL(string: "https://openverse.org")
+		}
+	}
+
+	/// Switch one source on or off, refusing to remove the last one left.
+	///
+	/// Rotation has to draw from somewhere, and an empty set would leave the app quietly doing nothing at every tick — indistinguishable, from the outside, from a broken app.
+	/// `WallpaperManager.decodeSources` already rescues an empty stored value; this keeps the UI from ever writing one in the first place.
+	nonisolated static func toggleKeepingOne(_ source: WallpaperSource, in enabled: Set<WallpaperSource>) -> Set<WallpaperSource> {
+		guard enabled.contains(source) else {
+			return enabled.union([source])
+		}
+
+		guard enabled.count > 1 else {
+			return enabled
+		}
+
+		return enabled.subtracting([source])
+	}
 }
 
 /// A wallpaper's source plus its id on that source, recovered from the local filename stem.

--- a/WallhavendTests/SourceRoutingTests.swift
+++ b/WallhavendTests/SourceRoutingTests.swift
@@ -99,4 +99,71 @@ final class SourceRoutingTests: XCTestCase {
 	func testUnknownKeysAreDroppedButKnownOnesSurvive() {
 		XCTAssertEqual(WallpaperManager.decodeSources("openverse,pexels"), [.openverse])
 	}
+
+	// MARK: - toggleKeepingOne: the only sets the UI is allowed to write
+
+	func testTogglingAnAbsentSourceAddsIt() {
+		XCTAssertEqual(
+			WallpaperSource.toggleKeepingOne(.openverse, in: [.wallhaven]),
+			[.wallhaven, .openverse]
+		)
+	}
+
+	func testTogglingOneOfTwoRemovesIt() {
+		XCTAssertEqual(
+			WallpaperSource.toggleKeepingOne(.wallhaven, in: [.wallhaven, .openverse]),
+			[.openverse]
+		)
+	}
+
+	func testTheLastSourceCannotBeTurnedOff() {
+		// An empty set would leave every tick quietly doing nothing, which from the outside is indistinguishable from a broken app.
+		for source in WallpaperSource.allCases {
+			XCTAssertEqual(WallpaperSource.toggleKeepingOne(source, in: [source]), [source])
+		}
+	}
+
+	func testTogglingStaysReversibleWhileTwoRemain() {
+		let both: Set<WallpaperSource> = [.wallhaven, .openverse]
+		let reduced = WallpaperSource.toggleKeepingOne(.openverse, in: both)
+
+		XCTAssertEqual(WallpaperSource.toggleKeepingOne(.openverse, in: reduced), both)
+	}
+
+	// MARK: - contentRatingCaption: which toggles the enabled sources actually read
+
+	func testNoCaptionWithoutOpenverse() {
+		// A Wallhaven-only install has to see exactly the screen it saw before sources existed.
+		XCTAssertNil(ContentTab.contentRatingCaption(enabled: [.wallhaven]))
+	}
+
+	func testCaptionSplitsTheTogglesWhenBothAreEnabled() {
+		let caption = ContentTab.contentRatingCaption(enabled: [.wallhaven, .openverse])
+
+		XCTAssertEqual(caption, "Wallhaven honors all three. Openverse reads only NSFW, which lets mature results through.")
+	}
+
+	func testCaptionNamesTheInertTogglesWhenOpenverseIsAlone() {
+		// SFW and Sketchy still render, and with Wallhaven off they do nothing — saying so is the whole point of the caption.
+		let caption = ContentTab.contentRatingCaption(enabled: [.openverse])
+
+		XCTAssertEqual(caption, "Openverse reads only NSFW, which lets mature results through — SFW and Sketchy apply to Wallhaven alone.")
+	}
+
+	// MARK: - source credits
+
+	func testEverySourceHasACreditAndSomewhereToLinkIt() {
+		for source in WallpaperSource.allCases {
+			XCTAssertFalse(source.attribution.isEmpty, "\(source.rawValue) has no credit line")
+			XCTAssertNotNil(source.homeURL, "\(source.rawValue) has no home URL")
+		}
+	}
+
+	func testOpenverseCreditCarriesTheWordingItsTermsRequire() {
+		// Openverse asks to be credited with a disclaimer of endorsement; paraphrasing it would break the terms its wallpapers arrive under.
+		XCTAssertEqual(
+			WallpaperSource.openverse.attribution,
+			"Made using Openverse — not endorsed or certified by Openverse"
+		)
+	}
 }


### PR DESCRIPTION
Third and last of the Openverse port. B1 taught the app to recover a wallpaper's source from its filename stem; B2 built the engine and routed fetches through it, but shipped it dark — `enabledSources` defaulted to Wallhaven alone and nothing could change that. This adds the controls, so the feature becomes reachable for the first time.

## The Content tab regroups by who owns each setting

Shared settings first, per-source settings after: Sources, Search, Categories (Wallhaven only), Content Rating, License (Openverse only). That's the order the Android sibling already ships, and it's the shape that absorbs a third source later — a new source appends a section and touches nothing else. The alternative, hiding individual controls based on which source is enabled, puts per-source knowledge inside a shared section and turns into a truth table as sources are added.

The API Key field moves under the same rule: it buys nothing while Wallhaven isn't being asked for wallpapers, so it goes away with it. Rotation and Wallpaper Pool are cross-source and stay put.

## Content Rating stays shared, and now admits what it does

Maturity is the one content control both sources understand, so the section is never gated. But only NSFW carries over — Openverse maps it onto allowing mature results and ignores the other two — which left SFW and Sketchy silently inert in an Openverse-only setup. A caption now names which toggles the enabled sources actually read.

The same gap exists in the Android app, filed there as Attacktive/Wallhavend-android#124. Normalizing the axis properly (one ordered level each source translates) is the real fix on both platforms, but it needs a migration and it shouldn't be designed around a third source whose needs aren't known yet.

## The last enabled source can't be switched off

An empty set would leave every tick quietly doing nothing, which from the outside is indistinguishable from a broken app. `decodeSources` already rescues an empty stored value; this keeps the UI from ever writing one.

## Credits

The footer credits each enabled source. Openverse's wording is set by its terms rather than by us, so it's reproduced verbatim and a test pins the exact string.

## Blocked rows

Now show the bare id with the source beneath, instead of the stored stem — `openverse_` in front of a 36-character UUID crowded the row and repeated what the source line says. This was scoped to B1 and shipped without; it lands here because this is the PR that makes Openverse wallpapers blockable at all.

## Default install

Unchanged apart from gaining the Sources block. Wallhaven-only shows no caption, no License section, and one credit line.