### PR TITLE
refactor: settle the formatting conventions

### DIFF
--- a/Wallhavend/AspectBucket.swift
+++ b/Wallhavend/AspectBucket.swift
@@ -17,11 +17,13 @@ enum AspectBucket: String, CaseIterable {
 		}
 	}
 
-	// Snap boundaries are midpoints between adjacent ratios:
-	//   (16/9 + 21/9)/2 ≈ 2.06   →  16x9 / 21x9 split
-	//   (16/10 + 16/9)/2 ≈ 1.69  →  16x10 / 16x9 split
-	//   (4/3 + 16/10)/2 ≈ 1.47   →  4x3 / 16x10 split
-	//   1.0                       →  portrait / landscape split
+	/*
+		Snap boundaries are midpoints between adjacent ratios:
+		  (16/9 + 21/9)/2 ≈ 2.06   →  16x9 / 21x9 split
+		  (16/10 + 16/9)/2 ≈ 1.69  →  16x10 / 16x9 split
+		  (4/3 + 16/10)/2 ≈ 1.47   →  4x3 / 16x10 split
+		  1.0                      →  portrait / landscape split
+	*/
 	static func snap(aspectRatio: Double) -> AspectBucket {
 		if aspectRatio >= 2.06 {
 			return .ultrawide

--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -1,11 +1,8 @@
 import SwiftUI
 
 struct ContentView: View {
-	@EnvironmentObject
-	var wallpaperManager: WallpaperManager
-
-	@EnvironmentObject
-	var wallhavenService: WallhavenService
+	@EnvironmentObject var wallpaperManager: WallpaperManager
+	@EnvironmentObject var wallhavenService: WallhavenService
 
 	@AppStorage("updateInterval")
 	private var updateInterval: TimeInterval = 60

--- a/Wallhavend/NetworkMonitor.swift
+++ b/Wallhavend/NetworkMonitor.swift
@@ -5,8 +5,7 @@ import Combine
 class NetworkMonitor: ObservableObject {
 	static let shared = NetworkMonitor()
 
-	@Published
-	private(set) var isOnline: Bool = true
+	@Published private(set) var isOnline: Bool = true
 
 	private let monitor = NWPathMonitor()
 	private let queue = DispatchQueue(label: "NetworkMonitor")
@@ -17,6 +16,7 @@ class NetworkMonitor: ObservableObject {
 				self?.isOnline = path.status == .satisfied
 			}
 		}
+
 		monitor.start(queue: queue)
 	}
 

--- a/Wallhavend/StatusBarController.swift
+++ b/Wallhavend/StatusBarController.swift
@@ -71,7 +71,12 @@ class StatusBarController: NSObject, NSMenuDelegate {
 		pinItem.image = NSImage(systemSymbolName: pinSymbol, accessibilityDescription: nil)
 		menu.addItem(pinItem)
 
-		let autoUpdateTitle = wallpaperManager.isRunning ? "Stop Auto Update" : "Start Auto Update"
+		let autoUpdateTitle = if wallpaperManager.isRunning {
+			"Stop Auto Update"
+		} else {
+			"Start Auto Update"
+		}
+
 		let autoUpdateItem = NSMenuItem(title: autoUpdateTitle, action: #selector(toggleAutoUpdate), keyEquivalent: "")
 		autoUpdateItem.target = self
 

--- a/Wallhavend/WallhavenAPI.swift
+++ b/Wallhavend/WallhavenAPI.swift
@@ -80,26 +80,22 @@ class WallhavenService: ObservableObject {
 
 	var selectedCategories: Set<WallhavenCategory> {
 		get {
-			Set(selectedCategoriesRaw.split(separator: ",")
-				.compactMap {
-					WallhavenCategory(rawValue: String($0))
-				}
+			Set(
+				selectedCategoriesRaw.split(separator: ",")
+					.compactMap { WallhavenCategory(rawValue: String($0)) }
 			)
 		}
 		set {
-			selectedCategoriesRaw = newValue.map {
-					$0.rawValue
-				}
+			selectedCategoriesRaw = newValue.map { $0.rawValue }
 				.joined(separator: ",")
 		}
 	}
 
 	var blockedIds: Set<String> {
 		get {
-			Set(blockedIdsRaw.split(separator: ",")
-				.map {
-					String($0)
-				}
+			Set(
+				blockedIdsRaw.split(separator: ",")
+					.map { String($0) }
 			)
 		}
 		set {
@@ -124,10 +120,9 @@ class WallhavenService: ObservableObject {
 	/// Stored exactly like `blockedIds`: a comma-joined string-set keyed on the wallhaven id (the local filename stem).
 	var pinnedIds: Set<String> {
 		get {
-			Set(pinnedIdsRaw.split(separator: ",")
-				.map {
-					String($0)
-				}
+			Set(
+				pinnedIdsRaw.split(separator: ",")
+					.map { String($0) }
 			)
 		}
 		set {
@@ -253,11 +248,16 @@ class WallhavenService: ObservableObject {
 	}
 
 	private func rawFetch(ratios: String, atleast: String) async throws -> [Wallpaper] {
-		let categories = selectedCategories.isEmpty ? [.general] : selectedCategories
+		let categories: Set<WallhavenCategory> = if selectedCategories.isEmpty { [.general] } else { selectedCategories }
+
 		let categoriesString = buildCategoriesString(categories)
 
 		let parts = Self.keywords(from: searchQuery)
-		let keywords: [String?] = parts.isEmpty ? [nil] : parts.map { Optional($0) }
+		let keywords: [String?] = if parts.isEmpty {
+			[nil]
+		} else {
+			parts.map { Optional($0) }
+		}
 
 		let requests: [URLRequest] = try keywords.map { keyword in
 			var components = URLComponents(string: "\(baseURL)/search")!
@@ -299,10 +299,8 @@ class WallhavenService: ObservableObject {
 	}
 
 	private func buildCategoriesString(_ categories: Set<WallhavenCategory>) -> String {
-		WallhavenCategory.allCases.map {
-				categories.contains($0) ? "1" : "0"
-		}
-		.joined()
+		WallhavenCategory.allCases.map { categories.contains($0) ? "1" : "0" }
+			.joined()
 	}
 
 	private func buildQueryItems(keyword: String?, categoriesString: String, ratios: String, atleast: String) -> [URLQueryItem] {

--- a/Wallhavend/WallhavendApp.swift
+++ b/Wallhavend/WallhavendApp.swift
@@ -2,8 +2,7 @@ import SwiftUI
 
 @main
 struct WallhavendApp: App {
-	@StateObject
-	private var wallpaperManager = WallpaperManager.shared
+	@StateObject private var wallpaperManager = WallpaperManager.shared
 	private let wallhavenService = WallhavenService.shared
 
 	@NSApplicationDelegateAdaptor(AppDelegate.self)

--- a/Wallhavend/WallpaperManager+Prefetch.swift
+++ b/Wallhavend/WallpaperManager+Prefetch.swift
@@ -201,8 +201,10 @@ extension WallpaperManager {
 			} catch is CancellationError {
 				return
 			} catch {
-				// Transient fetch/download failure (offline, no results, HTTP error). Stop this bucket quietly — prefetch
-				// is invisible, so it never touches the user-facing `error`; the next tick retries.
+				/*
+					Transient fetch/download failure (offline, no results, HTTP error).
+					Stop this bucket quietly — prefetch is invisible, so it never touches the user-facing `error`; the next tick retries.
+				*/
 				print("Prefetch stopped for \(bucket.rawValue): \(error)")
 				return
 			}

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -41,32 +41,7 @@ class WallpaperManager: ObservableObject {
 	private let networkMonitor = NetworkMonitor.shared
 	private var networkCancellable: AnyCancellable?
 
-	@Published
-	private(set) var isOnline: Bool = true
-
-	init() {
-		let stored = UserDefaults.standard.object(forKey: "poolSize") as? Int ?? 10
-		// "Current only" used to be 0; it's now 1 so the current wallpaper shows in the gallery. Migrate any persisted 0.
-		let migratedPoolSize = stored == 0 ? 1 : stored
-		if migratedPoolSize != stored {
-			UserDefaults.standard.set(migratedPoolSize, forKey: "poolSize")
-		}
-
-		_poolSize = Published(initialValue: migratedPoolSize)
-
-		let storedMode = UserDefaults.standard.string(forKey: "rotationMode")
-			.flatMap(RotationMode.init(rawValue:)) ?? .fresh
-
-		_rotationMode = Published(initialValue: storedMode)
-
-		_enabledSources = Published(initialValue: Self.decodeSources(UserDefaults.standard.string(forKey: "enabledSources")))
-
-		setupSessionObservers()
-		setupScreenLockObservers()
-		setupNetworkObserver()
-		loadPoolFromDisk()
-		setupSettingsObserver()
-	}
+	@Published private(set) var isOnline: Bool = true
 
 	private var autoUpdateTask: Task<Void, Never>?
 	private var timerInterval: TimeInterval = 60
@@ -99,32 +74,9 @@ class WallpaperManager: ObservableObject {
 		}
 	}
 
-	/// Comma-joined raw keys, sorted so the stored string doesn't churn on every write.
-	nonisolated static func encodeSources(_ sources: Set<WallpaperSource>) -> String {
-		sources.map { $0.rawValue }
-			.sorted()
-			.joined(separator: ",")
-	}
-
-	/// A missing, empty, or unrecognizable value falls back to Wallhaven.
-	/// Everything downstream assumes at least one source is enabled, and Wallhaven is the one that needs no opt-in.
-	nonisolated static func decodeSources(_ raw: String?) -> Set<WallpaperSource> {
-		let parsed = Set(
-			(raw ?? "").split(separator: ",")
-				.compactMap { WallpaperSource(rawValue: String($0)) }
-		)
-
-		return if parsed.isEmpty { [.wallhaven] } else { parsed }
-	}
-
-	@Published
-	var isRunning = false
-
-	@Published
-	var lastUpdated: Date?
-
-	@Published
-	var error: String?
+	@Published var isRunning = false
+	@Published var lastUpdated: Date?
+	@Published var error: String?
 
 	/// The in-flight background pool fill, if any. Held so settings changes, going offline, or stopping can cancel it.
 	var prefetchTask: Task<Void, Never>?
@@ -133,12 +85,10 @@ class WallpaperManager: ObservableObject {
 	var prefetchGeneration = 0
 
 	/// True while a background fill runs; drives the gallery's "Filling pool…" indicator.
-	@Published
-	var isPrefetching = false
+	@Published var isPrefetching = false
 
 	/// Best-effort count of wallpapers still to download in the current fill.
-	@Published
-	var prefetchRemaining = 0
+	@Published var prefetchRemaining = 0
 
 	/// Debounced observer of the search/pool settings that should refill the pool.
 	var topUpSettingsCancellable: AnyCancellable?
@@ -158,6 +108,48 @@ class WallpaperManager: ObservableObject {
 		}
 
 		return dateFormatter.string(from: lastUpdated)
+	}
+
+	init() {
+		let stored = UserDefaults.standard.object(forKey: "poolSize") as? Int ?? 10
+		// "Current only" used to be 0; it's now 1 so the current wallpaper shows in the gallery. Migrate any persisted 0.
+		let migratedPoolSize = if stored == 0 { 1 } else { stored }
+		if migratedPoolSize != stored {
+			UserDefaults.standard.set(migratedPoolSize, forKey: "poolSize")
+		}
+
+		_poolSize = Published(initialValue: migratedPoolSize)
+
+		let storedMode = UserDefaults.standard.string(forKey: "rotationMode")
+			.flatMap(RotationMode.init(rawValue:)) ?? .fresh
+
+		_rotationMode = Published(initialValue: storedMode)
+
+		_enabledSources = Published(initialValue: Self.decodeSources(UserDefaults.standard.string(forKey: "enabledSources")))
+
+		setupSessionObservers()
+		setupScreenLockObservers()
+		setupNetworkObserver()
+		loadPoolFromDisk()
+		setupSettingsObserver()
+	}
+
+	/// Comma-joined raw keys, sorted so the stored string doesn't churn on every write.
+	nonisolated static func encodeSources(_ sources: Set<WallpaperSource>) -> String {
+		sources.map { $0.rawValue }
+			.sorted()
+			.joined(separator: ",")
+	}
+
+	/// A missing, empty, or unrecognizable value falls back to Wallhaven.
+	/// Everything downstream assumes at least one source is enabled, and Wallhaven is the one that needs no opt-in.
+	nonisolated static func decodeSources(_ raw: String?) -> Set<WallpaperSource> {
+		let parsed = Set(
+			(raw ?? "").split(separator: ",")
+				.compactMap { WallpaperSource(rawValue: String($0)) }
+		)
+
+		return if parsed.isEmpty { [.wallhaven] } else { parsed }
 	}
 
 	func startAutoUpdate(interval: TimeInterval? = nil, tickImmediately: Bool = true) {


### PR DESCRIPTION
## Summary

- Property wrappers now follow one rule everywhere: a wrapper carrying an argument keeps its own line, an argument-less one sits inline with the declaration. That rule was already being followed perfectly by `@AppStorage` (13/13 own-line) and `@State` (3/3 inline) — it had just never been stated, so the argument-less `@Published`/`@EnvironmentObject` drifted both ways, splitting even within a single file (`WallpaperManager.swift`).
- `WallpaperManager.swift` had `init()` sitting in the middle of its stored properties, with the `encodeSources`/`decodeSources` pair interleaved further down. Properties now run uninterrupted, then `init()`, then the static codec, then the instance methods — the concern-based grouping inside the property block is untouched, and the reorder is content-identical apart from the wrapper joins and one `if` expression (verified by diffing sorted lines against `main`).
- Four ternaries in assignment position became `if` expressions. Seven remain, all in argument position, where Swift has no `if`-expression form.
- Single-site fixes: a missing blank line aftignment (`NetworkMonitor`), two stacked-`//`comment blocks converted to `/* */` (one of which was hard-wrapped mid-sentence), and `WallhavenAPI`'s over-indented accessor closures re-indented to match the `dy used elsewhere in the same file.

No behavior change.

## Test plan

- [x] `xcodebuild test` — 127/127 passing, un
- [x] `WallpaperManager.swift` reorder confirmed content-identical to `main` (sorted-line diff), apart from the six `@Published` joins and the one `if` expressio

🤖 Generated with [Claude Code](https://claud