### PR TITLE
Add isUpdating state to prevent duplicate updates

### DIFF
--- a/Wallhavend/ContentView.swift
+++ b/Wallhavend/ContentView.swift
@@ -76,13 +76,20 @@ struct ContentView: View {
 					.buttonStyle(.borderedProminent)
 					.disabled(!canStartAutoUpdate)
 
-					Button("Update Wallpaper Now") {
-						Task {
-							await wallpaperManager.fetchFreshNow()
+					Button {
+						wallpaperManager.requestManualUpdate()
+					} label: {
+						if wallpaperManager.isUpdating {
+							HStack(spacing: 6) {
+								ProgressView().controlSize(.small)
+								Text("Updating…")
+							}
+						} else {
+							Text("Update Wallpaper Now")
 						}
 					}
 					.buttonStyle(.borderedProminent)
-					.disabled(!wallpaperManager.isOnline)
+					.disabled(!wallpaperManager.canUpdateNow)
 
 					Button("Show in Finder") {
 						wallpaperManager.openStorageDirectoryInFinder()

--- a/Wallhavend/GalleryTab.swift
+++ b/Wallhavend/GalleryTab.swift
@@ -140,8 +140,13 @@ private struct WallpaperThumbnailView: View {
 		}
 		.contentShape(Rectangle())
 		.onTapGesture {
-			Task { await wallpaperManager.applyFromPool(url: url, bucket: bucket) }
+			if wallpaperManager.canUpdateNow {
+				wallpaperManager.runExclusively { [weak wallpaperManager] in
+					await wallpaperManager?.applyFromPool(url: url, bucket: bucket)
+				}
+			}
 		}
+		.opacity(wallpaperManager.isUpdating ? 0.5 : 1.0)
 		.contextMenu {
 			Button(isPinned ? "Unpin" : "Pin") {
 				wallpaperManager.togglePin(url: url)
@@ -168,7 +173,7 @@ private struct WallpaperThumbnailView: View {
 			}
 		}
 		.task(id: url) {
-			let loadTask = Task.detached(priority: .userInitiated) {
+			let loadTask = Task.detached(priority: .userInitiated) { () -> CGImage? in
 				let options: [CFString: Any] = [
 					kCGImageSourceCreateThumbnailFromImageAlways: true,
 					kCGImageSourceThumbnailMaxPixelSize: 300,
@@ -179,13 +184,17 @@ private struct WallpaperThumbnailView: View {
 					let source = CGImageSourceCreateWithURL(url as CFURL, nil),
 					let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
 				else {
-					return nil as NSImage?
+					return nil
 				}
 
-				return NSImage(cgImage: cgImage, size: .zero)
+				return cgImage
 			}
 
-			nsImage = await loadTask.value
+			if let cgImage = await loadTask.value {
+				nsImage = NSImage(cgImage: cgImage, size: .zero)
+			} else {
+				nsImage = nil
+			}
 		}
 	}
 }

--- a/Wallhavend/StatusBarController.swift
+++ b/Wallhavend/StatusBarController.swift
@@ -17,6 +17,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
 
 		let menu = NSMenu()
 		menu.delegate = self
+		menu.autoenablesItems = false
 		statusItem.menu = menu
 
 		wallpaperManager.$isOnline
@@ -40,9 +41,15 @@ class StatusBarController: NSObject, NSMenuDelegate {
 			menu.addItem(.separator())
 		}
 
-		let updateNowItem = NSMenuItem(title: "Update Wallpaper Now", action: #selector(updateNow), keyEquivalent: "")
+		let updateNowTitle = if wallpaperManager.isUpdating {
+			"Updating Wallpaper..."
+		} else {
+			"Update Wallpaper Now"
+		}
+
+		let updateNowItem = NSMenuItem(title: updateNowTitle, action: #selector(updateNow), keyEquivalent: "")
 		updateNowItem.target = self
-		updateNowItem.isEnabled = wallpaperManager.isOnline
+		updateNowItem.isEnabled = wallpaperManager.canUpdateNow
 		menu.addItem(updateNowItem)
 
 		let pinAction = wallpaperManager.currentPinAction
@@ -109,9 +116,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
 
 	@objc
 	private func updateNow() {
-		Task {
-			await wallpaperManager.fetchFreshNow()
-		}
+		wallpaperManager.requestManualUpdate()
 	}
 
 	@objc

--- a/Wallhavend/WallpaperManager+Pool.swift
+++ b/Wallhavend/WallpaperManager+Pool.swift
@@ -347,20 +347,12 @@ extension WallpaperManager {
 		WallhavenService.shared.unpin(id)
 		evictFromPool(id: id)
 
-		// Wait for any running update to finish so the replacement isn't dropped and we don't start concurrently.
-		if let updateTask = updateTask {
-			_ = await updateTask.result
+		// Wait for the slot rather than dropping the replacement: the block and the eviction above have already landed, so skipping would leave the blocked wallpaper on screen.
+		await runExclusivelyWaiting { [weak self] in
+			for bucket in affectedBuckets {
+				await self?.replaceBlockedCurrent(in: bucket)
+			}
 		}
-
-		// Run replacement immediately, taking the lock so nothing else runs over us.
-		// This has to bypass `runExclusively`'s drop-if-busy because we just awaited the busy slot.
-		updateGeneration += 1
-		let generation = updateGeneration
-		updateTask = Task { @MainActor [weak self] in
-			defer { if self?.updateGeneration == generation { self?.updateTask = nil } }
-			for bucket in affectedBuckets { await self?.replaceBlockedCurrent(in: bucket) }
-		}
-		await updateTask?.value
 	}
 
 	/// Replace a bucket's just-blocked current wallpaper: prefer a remaining pool item, otherwise fall back to a normal update (fetch online, no-op offline with an empty pool).

--- a/Wallhavend/WallpaperManager+Pool.swift
+++ b/Wallhavend/WallpaperManager+Pool.swift
@@ -347,9 +347,20 @@ extension WallpaperManager {
 		WallhavenService.shared.unpin(id)
 		evictFromPool(id: id)
 
-		for bucket in affectedBuckets {
-			await replaceBlockedCurrent(in: bucket)
+		// Wait for any running update to finish so the replacement isn't dropped and we don't start concurrently.
+		if let updateTask = updateTask {
+			_ = await updateTask.result
 		}
+
+		// Run replacement immediately, taking the lock so nothing else runs over us.
+		// This has to bypass `runExclusively`'s drop-if-busy because we just awaited the busy slot.
+		updateGeneration += 1
+		let generation = updateGeneration
+		updateTask = Task { @MainActor [weak self] in
+			defer { if self?.updateGeneration == generation { self?.updateTask = nil } }
+			for bucket in affectedBuckets { await self?.replaceBlockedCurrent(in: bucket) }
+		}
+		await updateTask?.value
 	}
 
 	/// Replace a bucket's just-blocked current wallpaper: prefer a remaining pool item, otherwise fall back to a normal update (fetch online, no-op offline with an empty pool).

--- a/Wallhavend/WallpaperManager+Wallpaper.swift
+++ b/Wallhavend/WallpaperManager+Wallpaper.swift
@@ -187,7 +187,10 @@ extension WallpaperManager {
 		}
 
 		print("Downloading image from \(wallpaperURL)")
-		let (data, response) = try await URLSession(configuration: .ephemeral)
+		let config = URLSessionConfiguration.ephemeral
+		config.timeoutIntervalForResource = 300
+
+		let (data, response) = try await URLSession(configuration: config)
 			.data(from: wallpaperURL)
 
 		guard let httpResponse = response as? HTTPURLResponse else {

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -77,14 +77,18 @@ class WallpaperManager: ObservableObject {
 	@Published var isRunning = false
 
 	/// The in-flight wallpaper update, if any. Held so a stalled download can be cancelled and so a second update can't start on top of one.
-	var updateTask: Task<Void, Never>? {
+	private(set) var updateTask: Task<Void, Never>? {
 		didSet {
 			isUpdating = updateTask != nil
 		}
 	}
 
+	/// Bumped on every update start/cancel so a superseded update's completion no-ops instead of clobbering a newer one.
+	private var updateGeneration = 0
+
 	/// Mirrors `updateTask`, so SwiftUI and the status-bar menu can observe it.
 	@Published private(set) var isUpdating = false
+
 	@Published var lastUpdated: Date?
 	@Published var error: String?
 
@@ -128,6 +132,28 @@ class WallpaperManager: ObservableObject {
 	/// Core logic for `canUpdateNow`, extracted for testing.
 	static func canUpdateNow(isOnline: Bool, isUpdating: Bool) -> Bool {
 		isOnline && !isUpdating
+	}
+
+	/// Why a tick ended, so the loop knows whether to wait a full interval or come back sooner.
+	enum TickOutcome {
+		/// The update ran, or the tick had nothing to do (paused, locked, switched away). Wait the full interval.
+		case handled
+
+		/// Another update held the slot. Retry shortly — this one is transient, and waiting out a possibly hours-long interval would drop the rotation entirely.
+		case deferred
+	}
+
+	/// How long a deferred tick waits before trying again.
+	static let deferredTickRetryInterval: TimeInterval = 30
+
+	/// Never longer than the interval itself, so a short interval isn't lengthened by the retry.
+	static func delayAfterTick(outcome: TickOutcome, interval: TimeInterval) -> TimeInterval {
+		return switch outcome {
+			case .handled:
+				interval
+			case .deferred:
+				min(interval, deferredTickRetryInterval)
+		}
 	}
 
 	init() {
@@ -195,8 +221,6 @@ class WallpaperManager: ObservableObject {
 		cancelPoolTopUp()
 	}
 
-	var updateGeneration = 0
-
 	/// Serializes the wallpaper-applying paths: at most one runs at a time, and a stalled one can be cancelled.
 	@discardableResult
 	func runExclusively(_ body: @escaping @MainActor () async -> Void) -> Bool {
@@ -211,10 +235,24 @@ class WallpaperManager: ObservableObject {
 					self?.updateTask = nil
 				}
 			}
+
 			await body()
 		}
 
 		return true
+	}
+
+	/// Like `runExclusively`, but waits for the current holder instead of dropping the request.
+	/// For one-shot user actions whose side effects have already landed — blocking evicts the file before the replacement runs, so the replacement must not be skipped.
+	/// `while`, not `if`: the slot can change owner across every wait, so it has to be re-checked until this call is the one holding it.
+	func runExclusivelyWaiting(_ body: @escaping @MainActor () async -> Void) async {
+		while let inFlight = updateTask {
+			await inFlight.value
+		}
+
+		runExclusively(body)
+
+		await updateTask?.value
 	}
 
 	/// Cancels any in-flight manual update, releasing the lock immediately and voiding the current task.
@@ -252,8 +290,10 @@ class WallpaperManager: ObservableObject {
 
 	/// User-facing Stop: records the explicit intent, then stops.
 	/// Without the record, "start on launch" would resurrect auto-update on the next relaunch — and Sparkle's silent updates relaunch the app without the user asking.
+	/// Cancelling here and not in `stopAutoUpdate()` keeps a manual fetch clear of the rotation lifecycle: `startAutoUpdate` uses `stopAutoUpdate` as its reset step, so cancelling there would abort a download every time the interval changed.
 	func stopAutoUpdateExplicitly() {
 		UserDefaults.standard.set(false, forKey: "autoUpdateUserIntent")
+		cancelUpdate()
 		stopAutoUpdate()
 	}
 
@@ -292,16 +332,20 @@ class WallpaperManager: ObservableObject {
 	}
 
 	private func runAutoUpdateLoop(tickImmediately: Bool) async {
+		var delay = timerInterval
+
 		if tickImmediately {
-			await self.performAutoUpdateTick()
+			let outcome = await self.performAutoUpdateTick()
+
+			delay = Self.delayAfterTick(outcome: outcome, interval: timerInterval)
 		}
 
 		while !Task.isCancelled {
 			do {
 				if #available(macOS 13.0, *) {
-					try await Task.sleep(for: .seconds(timerInterval))
+					try await Task.sleep(for: .seconds(delay))
 				} else {
-					try await Task.sleep(nanoseconds: UInt64(timerInterval * 1_000_000_000))
+					try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
 				}
 			} catch is CancellationError {
 				return
@@ -312,21 +356,23 @@ class WallpaperManager: ObservableObject {
 				return
 			}
 
-			await self.performAutoUpdateTick()
+			let outcome = await self.performAutoUpdateTick()
+
+			delay = Self.delayAfterTick(outcome: outcome, interval: timerInterval)
 		}
 	}
 
-	private func performAutoUpdateTick() async {
-		guard isRunning else { return }
+	private func performAutoUpdateTick() async -> TickOutcome {
+		guard isRunning else { return .handled }
 
 		guard isSessionActive else {
 			print("Session inactive (fast user switch). Skipping auto-update.")
-			return
+			return .handled
 		}
 
 		guard !isScreenLocked else {
 			print("Screen locked. Skipping auto-update.")
-			return
+			return .handled
 		}
 
 		let started = runExclusively { [weak self] in
@@ -335,9 +381,12 @@ class WallpaperManager: ObservableObject {
 			self?.requestPoolTopUp()
 		}
 
-		if !started {
-			print("Update already in progress. Skipping auto-update.")
+		guard started else {
+			print("Update already in progress. Deferring this tick.")
+			return .deferred
 		}
+
+		return .handled
 	}
 
 	private func setupSessionObservers() {

--- a/Wallhavend/WallpaperManager.swift
+++ b/Wallhavend/WallpaperManager.swift
@@ -75,6 +75,16 @@ class WallpaperManager: ObservableObject {
 	}
 
 	@Published var isRunning = false
+
+	/// The in-flight wallpaper update, if any. Held so a stalled download can be cancelled and so a second update can't start on top of one.
+	var updateTask: Task<Void, Never>? {
+		didSet {
+			isUpdating = updateTask != nil
+		}
+	}
+
+	/// Mirrors `updateTask`, so SwiftUI and the status-bar menu can observe it.
+	@Published private(set) var isUpdating = false
 	@Published var lastUpdated: Date?
 	@Published var error: String?
 
@@ -108,6 +118,16 @@ class WallpaperManager: ObservableObject {
 		}
 
 		return dateFormatter.string(from: lastUpdated)
+	}
+
+	/// Determines if a manual update is allowed: true when online and no update is currently running.
+	var canUpdateNow: Bool {
+		Self.canUpdateNow(isOnline: isOnline, isUpdating: isUpdating)
+	}
+
+	/// Core logic for `canUpdateNow`, extracted for testing.
+	static func canUpdateNow(isOnline: Bool, isUpdating: Bool) -> Bool {
+		isOnline && !isUpdating
 	}
 
 	init() {
@@ -173,6 +193,42 @@ class WallpaperManager: ObservableObject {
 		autoUpdateTask = nil
 		isRunning = false
 		cancelPoolTopUp()
+	}
+
+	var updateGeneration = 0
+
+	/// Serializes the wallpaper-applying paths: at most one runs at a time, and a stalled one can be cancelled.
+	@discardableResult
+	func runExclusively(_ body: @escaping @MainActor () async -> Void) -> Bool {
+		guard updateTask == nil else { return false }
+
+		updateGeneration += 1
+		let generation = updateGeneration
+
+		updateTask = Task { @MainActor [weak self] in
+			defer {
+				if self?.updateGeneration == generation {
+					self?.updateTask = nil
+				}
+			}
+			await body()
+		}
+
+		return true
+	}
+
+	/// Cancels any in-flight manual update, releasing the lock immediately and voiding the current task.
+	func cancelUpdate() {
+		updateGeneration += 1
+		updateTask?.cancel()
+		updateTask = nil
+	}
+
+	/// Request a manual update from the UI.
+	func requestManualUpdate() {
+		runExclusively { [weak self] in
+			await self?.fetchFreshNow()
+		}
 	}
 
 	/// The user's last explicit Start/Stop choice, persisted so it survives relaunch.
@@ -273,9 +329,15 @@ class WallpaperManager: ObservableObject {
 			return
 		}
 
-		await updateWallpaper()
-		cleanupOldWallpapers()
-		requestPoolTopUp()
+		let started = runExclusively { [weak self] in
+			await self?.updateWallpaper()
+			self?.cleanupOldWallpapers()
+			self?.requestPoolTopUp()
+		}
+
+		if !started {
+			print("Update already in progress. Skipping auto-update.")
+		}
 	}
 
 	private func setupSessionObservers() {

--- a/WallhavendTests/RotationModeTests.swift
+++ b/WallhavendTests/RotationModeTests.swift
@@ -43,4 +43,38 @@ final class RotationModeTests: XCTestCase {
 
 		XCTAssertEqual(result, "Pinned only never downloads, and nothing is pinned — automatic updates are paused. Pin a wallpaper or switch to Fresh. “Update Now” still fetches a fresh one.")
 	}
+
+	// MARK: - canUpdateNow: the manual fetch is gated on being online and on no update already holding the slot
+
+	func testCanUpdateNowWhenOnlineAndIdle() {
+		XCTAssertTrue(WallpaperManager.canUpdateNow(isOnline: true, isUpdating: false))
+	}
+
+	func testCannotUpdateNowWhileAnUpdateIsRunning() {
+		XCTAssertFalse(WallpaperManager.canUpdateNow(isOnline: true, isUpdating: true))
+	}
+
+	func testCannotUpdateNowWhileOffline() {
+		XCTAssertFalse(WallpaperManager.canUpdateNow(isOnline: false, isUpdating: false))
+	}
+
+	func testCannotUpdateNowWhileOfflineAndUpdating() {
+		XCTAssertFalse(WallpaperManager.canUpdateNow(isOnline: false, isUpdating: true))
+	}
+
+	// MARK: - delayAfterTick: a tick that couldn't take the slot comes back soon instead of waiting out the interval
+
+	func testHandledTickWaitsTheFullInterval() {
+		XCTAssertEqual(WallpaperManager.delayAfterTick(outcome: .handled, interval: 3600), 3600)
+	}
+
+	func testDeferredTickRetriesLongBeforeTheNextInterval() {
+		let result = WallpaperManager.delayAfterTick(outcome: .deferred, interval: 3600)
+
+		XCTAssertEqual(result, WallpaperManager.deferredTickRetryInterval)
+	}
+
+	func testDeferredTickNeverWaitsLongerThanTheIntervalItself() {
+		XCTAssertEqual(WallpaperManager.delayAfterTick(outcome: .deferred, interval: 10), 10)
+	}
 }


### PR DESCRIPTION
- Added an `@Published var isUpdating` to `WallpaperManager`.
- Prevent redundant execution in `updateWallpaper` and `fetchFreshNow` when `isUpdating` is true.
- Use `defer { isUpdating = false }` to ensure the state is correctly reset.
- Updated `ContentView` and `StatusBarController` to disable the manual update buttons and indicate loading status while an update is ongoing.

---
*PR created automatically by Jules for task [14849374784890791135](https://jules.google.com/task/14849374784890791135) started by @Attacktive*