### PR TITLE
fix: sign the released app and bump Sparkle to 2.9.6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,8 @@ jobs:
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
-          curl -L -o /tmp/Sparkle.tar.xz https://github.com/sparkle-project/Sparkle/releases/download/2.9.0/Sparkle-2.9.0.tar.xz
+          # Keep this in step with the Sparkle version resolved in Package.resolved.
+          curl -L -o /tmp/Sparkle.tar.xz https://github.com/sparkle-project/Sparkle/releases/download/2.9.6/Sparkle-2.9.6.tar.xz
           tar -xf /tmp/Sparkle.tar.xz -C /tmp
           echo "$SPARKLE_PRIVATE_KEY" | /tmp/bin/sign_update --ed-key-file - -p ./build/Wallhavend.zip > ./build/Wallhavend.zip.sig
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,14 @@ jobs:
           mkdir -p ./build/export
           cp -R ./build/Wallhavend.xcarchive/Products/Applications/Wallhavend.app ./build/export/
 
+      - name: 'Sign App'
+        run: |
+          # `CODE_SIGNING_ALLOWED=NO` above leaves the bundle with only a linker-signed executable and no `_CodeSignature`, which `SecCodeCopyDesignatedRequirement` reports as unsigned.
+          # Sparkle refuses to replace a code-signed app with an unsigned one, and its own error says ad-hoc signing is the minimum it accepts.
+          # Signing here also re-seals Sparkle.framework, whose signature the embed step invalidates by stripping the headers it covers.
+          codesign --force --deep --sign - ./build/export/Wallhavend.app
+          codesign --verify --deep --strict ./build/export/Wallhavend.app
+
       - name: 'Create DMG'
         run: |
           brew install create-dmg

--- a/Wallhavend.xcodeproj/project.pbxproj
+++ b/Wallhavend.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.9.0;
+				minimumVersion = 2.9.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Wallhavend.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Wallhavend.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
-        "version" : "2.9.4"
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     }
   ],


### PR DESCRIPTION
## Problem

Updating from a locally built copy fails with "The update is improperly signed and could not be validated."

The EdDSA signature is not at fault — the published `Wallhavend.zip` verifies cleanly against the `SUPublicEDKey` in `Info.plist`. The archive step passes `CODE_SIGNING_ALLOWED=NO`, so the exported bundle carries only a linker-signed executable and no `_CodeSignature`. Sparkle's `bundleAtURLIsCodeSigned:` calls `SecCodeCopyDesignatedRequirement`, which answers `errSecCSUnsigned` for that shape, and its update policy refuses to replace a code-signed app with an unsigned one:

> The old bundle is code signed but the update is not code signed. Sparkle only supports rotation, but not removal of Apple Code Signing identity. Please code sign the new app. If no Apple Code Signing certificate is available, adhoc signing can be used at minimum.

`SPUInstallerDriver` rewraps that `SUValidationError` into the generic sentence the alert shows.

Only a code-signed host hits this. An install from the release DMG is itself unsigned, so the policy lets the update through — which is why it went unnoticed. Every release artifact so far (2.9.0, 2.10.1, 2.11.0) lacks `_CodeSignature`.

## Changes

**Ad-hoc sign the exported app** before the DMG and ZIP are built, which is exactly what Sparkle's error asks for, and verify it so the job fails loudly if signing ever stops working. This also re-seals `Sparkle.framework`, whose signature the embed step invalidates by stripping the `PrivateHeaders` its `CodeResources` still covers — `codesign --verify --deep --strict` rejects the current artifact for that reason alone.